### PR TITLE
Fixes for Debian

### DIFF
--- a/bar/Makefile
+++ b/bar/Makefile
@@ -9,7 +9,7 @@ PREFIX ?= /usr
 all: $(SOURCES) $(EXECUTABLE) 
 
 $(EXECUTABLE): $(OBJECTS) 
-	$(CC) $(OBJECTS) -o $@ `pkg-config gtkmm-3.0 --libs --cflags`
+	$(CC) $(OBJECTS) -o $@ `pkg-config gtkmm-3.0 --libs --cflags` -lstdc++fs
 
 .cc.o:
 	$(CC) $(CFLAGS) $< -o $@ `pkg-config gtkmm-3.0 --libs --cflags`

--- a/bar/bar.cc
+++ b/bar/bar.cc
@@ -195,10 +195,6 @@ int main(int argc, char *argv[]) {
     MainWindow window;
     
     window.signal_button_press_event().connect(sigc::ptr_fun(&on_window_clicked));
-    // This prevents openbox window from receiving keyboard enents
-    if (wm != "openbox") {
-		window.set_skip_taskbar_hint(true);
-	}
 
     /* Detect focused display geometry: {x, y, width, height} */
     std::vector<int> geometry = display_geometry(wm, window);

--- a/bar/bar_tools.cpp
+++ b/bar/bar_tools.cpp
@@ -186,7 +186,7 @@ Gtk::Image* app_image(std::string icon) {
 
 	if (icon.find_first_of("/") != 0) {
 		try {
-			pixbuf = icon_theme->load_icon(icon, image_size, Gtk::ICON_LOOKUP_USE_BUILTIN);
+			pixbuf = icon_theme->load_icon(icon, image_size, Gtk::ICON_LOOKUP_FORCE_SIZE);
 		} catch (...) {
 			pixbuf = Gdk::Pixbuf::create_from_file("/usr/share/nwggrid/icon-missing.svg", image_size, image_size, true);
 		}

--- a/dmenu/Makefile
+++ b/dmenu/Makefile
@@ -9,7 +9,7 @@ PREFIX ?= /usr
 all: $(SOURCES) $(EXECUTABLE) 
 
 $(EXECUTABLE): $(OBJECTS) 
-	$(CC) $(OBJECTS) -o $@ `pkg-config gtkmm-3.0 --libs --cflags`
+	$(CC) $(OBJECTS) -o $@ `pkg-config gtkmm-3.0 --libs --cflags` -lstdc++fs
 
 .cc.o:
 	$(CC) $(CFLAGS) $< -o $@ `pkg-config gtkmm-3.0 --libs --cflags`

--- a/dmenu/dmenu.cc
+++ b/dmenu/dmenu.cc
@@ -194,11 +194,6 @@ int main(int argc, char *argv[]) {
     window.anchor = &anchor;
     
     window.signal_button_press_event().connect(sigc::ptr_fun(&on_window_clicked));
-    
-    // This prevents openbox window from receiving keyboard enents
-    if (wm != "openbox") {
-		window.set_skip_taskbar_hint(true);
-	}
 
     /* Detect focused display geometry: {x, y, width, height} */
     std::vector<int> geometry = display_geometry(wm, window);

--- a/grid/Makefile
+++ b/grid/Makefile
@@ -9,7 +9,7 @@ PREFIX ?= /usr
 all: $(SOURCES) $(EXECUTABLE) 
 
 $(EXECUTABLE): $(OBJECTS) 
-	$(CC) $(OBJECTS) -o $@ `pkg-config gtkmm-3.0 --libs --cflags`
+	$(CC) $(OBJECTS) -o $@ `pkg-config gtkmm-3.0 --libs --cflags` -lstdc++fs
 
 .cc.o:
 	$(CC) $(CFLAGS) $< -o $@ `pkg-config gtkmm-3.0 --libs --cflags`

--- a/grid/grid.cc
+++ b/grid/grid.cc
@@ -217,10 +217,6 @@ int main(int argc, char *argv[]) {
     MainWindow window;
     
     window.signal_button_press_event().connect(sigc::ptr_fun(&on_window_clicked));
-    // This prevents openbox window from receiving keyboard enents
-    if (wm != "openbox") {
-		window.set_skip_taskbar_hint(true);
-	}
 
     /* Detect focused display geometry: {x, y, width, height} */
     std::vector<int> geometry = display_geometry(wm, window);

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -95,7 +95,7 @@ bool on_button_focused(GdkEventFocus* event, Glib::ustring comment) {
 bool MainWindow::on_key_press_event(GdkEventKey* key_event) {
 	if (key_event -> keyval == GDK_KEY_Escape) {
 		Gtk::Main::quit();
-		return true;
+		return Gtk::Window::on_key_press_event(key_event);
 
 	} else if (((key_event -> keyval >= GDK_KEY_A && key_event -> keyval <= GDK_KEY_Z)
 			|| (key_event -> keyval >= GDK_KEY_a && key_event -> keyval <= GDK_KEY_z)

--- a/grid/grid_tools.cpp
+++ b/grid/grid_tools.cpp
@@ -346,7 +346,7 @@ Gtk::Image* app_image(std::string icon) {
 
 	if (icon.find_first_of("/") != 0) {
 		try {
-			pixbuf = icon_theme->load_icon(icon, image_size, Gtk::ICON_LOOKUP_USE_BUILTIN);
+			pixbuf = icon_theme->load_icon(icon, image_size, Gtk::ICON_LOOKUP_FORCE_SIZE);
 		} catch (...) {
 			pixbuf = Gdk::Pixbuf::create_from_file("/usr/share/nwggrid/icon-missing.svg", image_size, image_size, true);
 		}


### PR DESCRIPTION
- `-lstc++fs` needed as g++ argument;
- `skip_taskbar_hint` finally turned off for all WMs, as it gets us in trouble on Openbox.