### PR TITLE
nwgdmenu -n argument to turn the search box off

### DIFF
--- a/dmenu/dmenu.cc
+++ b/dmenu/dmenu.cc
@@ -27,6 +27,7 @@ int main(int argc, char *argv[]) {
         std::cout << "Options [-h] [-ha <l>|<r>] [-va <t>|<b>] [-r <rows>] [-c <name>] [-o <opacity>]\n\n";
         std::cout << "Options:\n";
         std::cout << "-h            show this help message and exit\n";
+        std::cout << "-n            no search box\n";
         std::cout << "-ha <l>|<r>   horizontal alignment left/right (default: center)\n";
         std::cout << "-va <t>|<b>   vertical alignment top/bottom (default: middle)\n";
         std::cout << "-r <rows>     number of rows (default: " << rows <<")\n";
@@ -58,6 +59,10 @@ int main(int argc, char *argv[]) {
         const char *command = cmd.c_str();
         std::system(command);
         std::exit(0);
+    }
+
+    if (input.cmdOptionExists("-n")){
+        show_searchbox = false;
     }
 
     const std::string &halign = input.getCmdOption("-ha");
@@ -251,11 +256,13 @@ int main(int argc, char *argv[]) {
         //~ window.hide();
     }
 
-    Gtk::MenuItem *search_item = new Gtk::MenuItem();
-    search_item -> add(menu.searchbox);
-    search_item -> set_name("search_item");
-    search_item -> set_sensitive(false);
-    menu.append(*search_item);
+    if (show_searchbox) {
+        Gtk::MenuItem *search_item = new Gtk::MenuItem();
+        search_item -> add(menu.searchbox);
+        search_item -> set_name("search_item");
+        search_item -> set_sensitive(false);
+        menu.append(*search_item);
+    }
 
     menu.signal_deactivate().connect(sigc::ptr_fun(Gtk::Main::quit));
 
@@ -270,6 +277,7 @@ int main(int argc, char *argv[]) {
             break;
         }
     }
+    
     menu.set_reserve_toggle_size(false);
     menu.set_property("width_request", (int)(w / 8));
 

--- a/dmenu/dmenu.h
+++ b/dmenu/dmenu.h
@@ -30,6 +30,7 @@ std::string custom_css_file {"style.css"};
 int rows (20);                              // number of menu items to display
 std::vector<Glib::ustring> all_commands {};
 bool dmenu_run = false;
+bool show_searchbox = true;                 // if to show search box
 
 #ifndef NWG_DMENU_ANCHOR_H
 #define NWG_DMENU_ANCHOR_H

--- a/dmenu/dmenu_classes.cc
+++ b/dmenu/dmenu_classes.cc
@@ -57,30 +57,32 @@ DMenu::~DMenu() {
 }
 
 bool DMenu::on_key_press_event(GdkEventKey* key_event) {
-    if (key_event -> keyval == GDK_KEY_Escape) {
-        Gtk::Main::quit();
-        return Gtk::Menu::on_key_press_event(key_event);
-    } else if (((key_event -> keyval >= GDK_KEY_A && key_event -> keyval <= GDK_KEY_Z)
-        || (key_event -> keyval >= GDK_KEY_a && key_event -> keyval <= GDK_KEY_z)
-        || (key_event -> keyval >= GDK_KEY_0 && key_event -> keyval <= GDK_KEY_9)
-        || key_event -> keyval == GDK_KEY_plus
-        || key_event -> keyval == GDK_KEY_minus
-        || key_event -> keyval == GDK_KEY_underscore
-        || key_event -> keyval == GDK_KEY_hyphen)
-        && key_event->type == GDK_KEY_PRESS) {
+    if (show_searchbox) {
+        if (key_event -> keyval == GDK_KEY_Escape) {
+            Gtk::Main::quit();
+            return Gtk::Menu::on_key_press_event(key_event);
+        } else if (((key_event -> keyval >= GDK_KEY_A && key_event -> keyval <= GDK_KEY_Z)
+            || (key_event -> keyval >= GDK_KEY_a && key_event -> keyval <= GDK_KEY_z)
+            || (key_event -> keyval >= GDK_KEY_0 && key_event -> keyval <= GDK_KEY_9)
+            || key_event -> keyval == GDK_KEY_plus
+            || key_event -> keyval == GDK_KEY_minus
+            || key_event -> keyval == GDK_KEY_underscore
+            || key_event -> keyval == GDK_KEY_hyphen)
+            && key_event->type == GDK_KEY_PRESS) {
 
-        char character = key_event -> keyval;
-        this -> search_phrase += character;
+            char character = key_event -> keyval;
+            this -> search_phrase += character;
 
-        this -> searchbox.set_text(this -> search_phrase);
-        this -> filter_view();
-        return true;
+            this -> searchbox.set_text(this -> search_phrase);
+            this -> filter_view();
+            return true;
 
-    } else if (key_event -> keyval == GDK_KEY_BackSpace && this -> search_phrase.size() > 0) {
-        this -> search_phrase = this -> search_phrase.substr(0, this -> search_phrase.size() - 1);
-        this -> searchbox.set_text(this -> search_phrase);
-        this -> filter_view();
-        return true;
+        } else if (key_event -> keyval == GDK_KEY_BackSpace && this -> search_phrase.size() > 0) {
+            this -> search_phrase = this -> search_phrase.substr(0, this -> search_phrase.size() - 1);
+            this -> searchbox.set_text(this -> search_phrase);
+            this -> filter_view();
+            return true;
+        }
     }
     //if the event has not been handled, call the base class
     return Gtk::Menu::on_key_press_event(key_event);


### PR DESCRIPTION
In small pipe menus the searchbox is useless, so let's have a way to turn it off.