### PR TITLE
Add meson build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@
 
 # Project files
 *.geany
+
+subprojects/nlohmann_json
+builddir

--- a/bar/bar.cc
+++ b/bar/bar.cc
@@ -124,7 +124,7 @@ int main(int argc, char *argv[]) {
     std::string config_dir = get_config_dir();
     if (!fs::is_directory(config_dir)) {
         std::cout << "Config dir not found, creating...\n";
-        fs::create_directory(config_dir);
+        fs::create_directories(config_dir);
     }
 
     // default and custom style sheet
@@ -132,26 +132,21 @@ int main(int argc, char *argv[]) {
     // css file to be used
     std::string css_file = config_dir + "/" + custom_css_file;
     // copy default file if not found
-    const char *custom_css = css_file.c_str();
     if (!fs::exists(default_css_file)) {
-        fs::path source_file = "/usr/share/nwgbar/style.css";
-        fs::path target = default_css_file;
         try {
-            fs::copy_file("/usr/share/nwgbar/style.css", target, fs::copy_options::overwrite_existing);
+            fs::copy_file(DATA_DIR_STR "/nwgbar/style.css", default_css_file, fs::copy_options::overwrite_existing);
         } catch (...) {
             std::cout << "Failed copying default style.css\n";
         }
     }
 
     // default or custom template
-    std::string bar_file = config_dir + "/" + definition_file;
+    std::string default_bar_file = config_dir + "/bar.json";
+    std::string custom_bar_file = config_dir + "/" + definition_file;
     // copy default anyway if not found
-    const char *custom_bar = bar_file.c_str();
-    if (!fs::exists(config_dir + "/bar.json")) {
-        fs::path source_file = "/usr/share/nwgbar/bar.json";
-        fs::path target = bar_file;
+    if (!fs::exists(default_bar_file)) {
         try {
-            fs::copy_file("/usr/share/nwgbar/bar.json", target, fs::copy_options::overwrite_existing);
+            fs::copy_file(DATA_DIR_STR "/nwgbar/bar.json", default_bar_file, fs::copy_options::overwrite_existing);
         } catch (...) {
             std::cout << "Failed copying default template\n";
         }
@@ -159,10 +154,10 @@ int main(int argc, char *argv[]) {
 
     ns::json bar_json {};
     try {
-        bar_json = get_bar_json(custom_bar);
+        bar_json = get_bar_json(custom_bar_file);
     }  catch (...) {
         std::cout << "\nERROR: Template file not found, using default\n";
-        bar_json = get_bar_json("/usr/share/nwgbar/bar.json");
+        bar_json = get_bar_json(default_bar_file);
     }
     std::cout << bar_json.size() << " bar entries loaded\n";
 
@@ -194,12 +189,12 @@ int main(int argc, char *argv[]) {
     GdkDisplay* display = gdk_display_get_default();
     GdkScreen* screen = gdk_display_get_default_screen(display);
     gtk_style_context_add_provider_for_screen(screen, GTK_STYLE_PROVIDER(provider), GTK_STYLE_PROVIDER_PRIORITY_USER);
-    if (std::ifstream(custom_css)) {
-        gtk_css_provider_load_from_path(provider, custom_css, NULL);
-        std::cout << "Using " << custom_css << std::endl;
+    if (std::ifstream(custom_css_file)) {
+        gtk_css_provider_load_from_path(provider, custom_css_file.c_str(), NULL);
+        std::cout << "Using " << custom_css_file << std::endl;
     } else {
-        gtk_css_provider_load_from_path(provider, "/usr/share/nwgbar/style.css", NULL);
-        std::cout << "Using /usr/share/nwgbar/style.css\n";
+        gtk_css_provider_load_from_path(provider, default_css_file.c_str(), NULL);
+        std::cout << "Using " << default_css_file << std::endl;
     }
     g_object_unref(provider);
 

--- a/bar/bar.h
+++ b/bar/bar.h
@@ -6,6 +6,7 @@
  * License: GPL3
  * */
 
+#include "../nwgconfig.h"
 #include <iostream>
 #include "../version.h"
 #include <fstream>

--- a/bar/bar_tools.cpp
+++ b/bar/bar_tools.cpp
@@ -9,18 +9,19 @@
 /*
  * Returns config dir
  * */
+
 std::string get_config_dir() {
-    std::string s = "";
+    std::string s;
     char* val = getenv("XDG_CONFIG_HOME");
     if (val) {
         s = val;
-        s += "/nwgbar";
+        s += "/nwg-launchers/nwgbar";
     } else {
-        char* val = getenv("HOME");
+        val = getenv("HOME");
         s = val;
-        s += "/.config/nwgbar";
+        s += "/.config/nwg-launchers/nwgbar";
     }
-    fs::path dir (s);
+
     return s;
 }
 
@@ -183,13 +184,13 @@ Gtk::Image* app_image(std::string icon) {
         try {
             pixbuf = icon_theme->load_icon(icon, image_size, Gtk::ICON_LOOKUP_FORCE_SIZE);
         } catch (...) {
-            pixbuf = Gdk::Pixbuf::create_from_file("/usr/share/nwggrid/icon-missing.svg", image_size, image_size, true);
+            pixbuf = Gdk::Pixbuf::create_from_file(DATA_DIR_STR "/nwgbar/icon-missing.svg", image_size, image_size, true);
         }
     } else {
         try {
             pixbuf = Gdk::Pixbuf::create_from_file(icon, image_size, image_size, true);
         } catch (...) {
-            pixbuf = Gdk::Pixbuf::create_from_file("/usr/share/nwggrid/icon-missing.svg", image_size, image_size, true);
+            pixbuf = Gdk::Pixbuf::create_from_file(DATA_DIR_STR "/nwgbar/icon-missing.svg", image_size, image_size, true);
         }
     }
     auto image = Gtk::manage(new Gtk::Image(pixbuf));

--- a/bar/meson.build
+++ b/bar/meson.build
@@ -1,0 +1,16 @@
+sources = files(
+	'bar.cc'
+)
+
+executable(
+	'nwgbar',
+	sources,
+	dependencies: [json, gtkmm],
+	include_directories: json_header_dir,
+	install: true
+)
+
+install_data(
+	['style.css', 'bar.json', 'icon-missing.svg'],
+	install_dir: conf_data.get('datadir', '') / 'nwgbar'
+)

--- a/dmenu/dmenu.cc
+++ b/dmenu/dmenu.cc
@@ -128,7 +128,7 @@ int main(int argc, char *argv[]) {
     std::string config_dir = get_config_dir();
     if (!fs::is_directory(config_dir)) {
         std::cout << "Config dir not found, creating...\n";
-        fs::create_directory(config_dir);
+        fs::create_directories(config_dir);
     }
 
     // default and custom style sheet
@@ -136,12 +136,9 @@ int main(int argc, char *argv[]) {
     // css file to be used
     std::string css_file = config_dir + "/" + custom_css_file;
     // copy default file if not found
-    const char *custom_css = css_file.c_str();
     if (!fs::exists(default_css_file)) {
-        fs::path source_file = "/usr/share/nwgdmenu/style.css";
-        fs::path target = default_css_file;
         try {
-            fs::copy_file("/usr/share/nwgdmenu/style.css", target, fs::copy_options::overwrite_existing);
+            fs::copy_file(DATA_DIR_STR "/nwgdmenu/style.css", default_css_file, fs::copy_options::overwrite_existing);
         } catch (...) {
             std::cout << "Failed copying default style.css\n";
         }
@@ -197,10 +194,10 @@ int main(int argc, char *argv[]) {
     GdkDisplay* display = gdk_display_get_default();
     GdkScreen* screen = gdk_display_get_default_screen(display);
     gtk_style_context_add_provider_for_screen(screen, GTK_STYLE_PROVIDER(provider), GTK_STYLE_PROVIDER_PRIORITY_USER);
-    if (std::ifstream(custom_css)) {
-        gtk_css_provider_load_from_path(provider, custom_css, NULL);
+    if (std::ifstream(custom_css_file)) {
+        gtk_css_provider_load_from_path(provider, custom_css_file.c_str(), NULL);
     } else {
-        gtk_css_provider_load_from_path(provider, "/usr/share/nwgdmenu/style.css", NULL);
+        gtk_css_provider_load_from_path(provider, default_css_file.c_str(), NULL);
     }
     g_object_unref(provider);
 

--- a/dmenu/dmenu.h
+++ b/dmenu/dmenu.h
@@ -6,6 +6,7 @@
  * License: GPL3
  * */
 
+#include "../nwgconfig.h"
 #include <iostream>
 #include "../version.h"
 #include <fstream>

--- a/dmenu/dmenu_tools.cpp
+++ b/dmenu/dmenu_tools.cpp
@@ -10,17 +10,16 @@
  * Returns config dir
  * */
 std::string get_config_dir() {
-    std::string s = "";
+    std::string s;
     char* val = getenv("XDG_CONFIG_HOME");
     if (val) {
         s = val;
-        s += "/nwgdmenu";
+        s += "/nwg-launchers/nwgdmenu";
     } else {
-        char* val = getenv("HOME");
+        val = getenv("HOME");
         s = val;
-        s += "/.config/nwgdmenu";
+        s += "/.config/nwg-launchers/nwgdmenu";
     }
-    fs::path dir (s);
     return s;
 }
 

--- a/dmenu/meson.build
+++ b/dmenu/meson.build
@@ -1,0 +1,16 @@
+sources = files(
+	'dmenu.cc'
+)
+
+executable(
+	'nwgdmenu',
+	sources,
+	dependencies: [json, gtkmm],
+	include_directories: json_header_dir,
+	install: true
+)
+
+install_data(
+	['style.css'],
+	install_dir: conf_data.get('datadir', '') / 'nwgdmenu'
+)

--- a/grid/grid.cc
+++ b/grid/grid.cc
@@ -148,7 +148,7 @@ int main(int argc, char *argv[]) {
     std::string config_dir = get_config_dir();
     if (!fs::is_directory(config_dir)) {
         std::cout << "Config dir not found, creating...\n";
-        fs::create_directory(config_dir);
+        fs::create_directories(config_dir);
     }
 
     // default and custom style sheet
@@ -156,12 +156,9 @@ int main(int argc, char *argv[]) {
     // css file to be used
     std::string css_file = config_dir + "/" + custom_css_file;
     // copy default file if not found
-    const char *custom_css = css_file.c_str();
     if (!fs::exists(default_css_file)) {
-        fs::path source_file = "/usr/share/nwggrid/style.css";
-        fs::path target = default_css_file;
         try {
-            fs::copy_file("/usr/share/nwggrid/style.css", target, fs::copy_options::overwrite_existing);
+            fs::copy_file(DATA_DIR_STR "/nwggrid/style.css", default_css_file, fs::copy_options::overwrite_existing);
         } catch (...) {
             std::cout << "Failed copying default style.css\n";
         }
@@ -237,12 +234,12 @@ int main(int argc, char *argv[]) {
     GdkDisplay* display = gdk_display_get_default();
     GdkScreen* screen = gdk_display_get_default_screen(display);
     gtk_style_context_add_provider_for_screen(screen, GTK_STYLE_PROVIDER(provider), GTK_STYLE_PROVIDER_PRIORITY_USER);
-    if (std::ifstream(custom_css)) {
-        gtk_css_provider_load_from_path(provider, custom_css, NULL);
-        std::cout << "Using " << custom_css << std::endl;
+    if (std::ifstream(custom_css_file)) {
+        gtk_css_provider_load_from_path(provider, custom_css_file.c_str(), NULL);
+        std::cout << "Using " << custom_css_file << std::endl;
     } else {
-        gtk_css_provider_load_from_path(provider, "/usr/share/nwggrid/style.css", NULL);
-        std::cout << "Using /usr/share/nwggrid/style.css\n";
+        gtk_css_provider_load_from_path(provider, default_css_file.c_str(), NULL);
+        std::cout << default_css_file << std::endl;
     }
     g_object_unref(provider);
 

--- a/grid/grid.h
+++ b/grid/grid.h
@@ -6,6 +6,7 @@
  * License: GPL3
  * */
 
+#include "../nwgconfig.h"
 #include <iostream>
 #include "../version.h"
 #include <fstream>

--- a/grid/grid_tools.cpp
+++ b/grid/grid_tools.cpp
@@ -50,17 +50,16 @@ std::string get_pinned_path() {
  * Returns config dir
  * */
 std::string get_config_dir() {
-    std::string s = "";
+    std::string s;
     char* val = getenv("XDG_CONFIG_HOME");
     if (val) {
         s = val;
-        s += "/nwggrid";
+        s += "/nwg-launchers/nwggrid";
     } else {
-        char* val = getenv("HOME");
+        val = getenv("HOME");
         s = val;
-        s += "/.config/nwggrid";
+        s += "/.config/nwg-launchers/nwggrid";
     }
-    fs::path dir (s);
     return s;
 }
 
@@ -451,13 +450,13 @@ Gtk::Image* app_image(std::string icon) {
         try {
             pixbuf = icon_theme->load_icon(icon, image_size, Gtk::ICON_LOOKUP_FORCE_SIZE);
         } catch (...) {
-            pixbuf = Gdk::Pixbuf::create_from_file("/usr/share/nwggrid/icon-missing.svg", image_size, image_size, true);
+            pixbuf = Gdk::Pixbuf::create_from_file(DATA_DIR_STR "/nwggrid/icon-missing.svg", image_size, image_size, true);
         }
     } else {
         try {
             pixbuf = Gdk::Pixbuf::create_from_file(icon, image_size, image_size, true);
         } catch (...) {
-            pixbuf = Gdk::Pixbuf::create_from_file("/usr/share/nwggrid/icon-missing.svg", image_size, image_size, true);
+            pixbuf = Gdk::Pixbuf::create_from_file(DATA_DIR_STR "/nwggrid/icon-missing.svg", image_size, image_size, true);
         }
     }
     auto image = Gtk::manage(new Gtk::Image(pixbuf));

--- a/grid/meson.build
+++ b/grid/meson.build
@@ -1,0 +1,16 @@
+sources = files(
+	'grid.cc'
+)
+
+executable(
+	'nwggrid',
+	sources,
+	dependencies: [json, gtkmm],
+	include_directories: json_header_dir,
+	install: true
+)
+
+install_data(
+	['style.css', 'icon-missing.svg'],
+	install_dir: conf_data.get('datadir', '') / 'nwggrid'
+)

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,45 @@
+project('nwg-launchers', 'cpp',
+	default_options: [
+			'cpp_std=c++17',
+			'warning_level=3'
+			],
+	license: 'GPL-3.0-or-later',
+	version: '0.1.9'
+)
+
+add_global_link_arguments('-lstdc++fs', language: 'cpp')
+
+# Dependencies
+gtkmm = dependency('gtkmm-3.0', required: true)
+json = dependency('nlohmann_json', required: false)
+
+# If nlohmann-json is not installed on the system
+# we download the repository and use the single header file they have
+json_header_dir = []
+if not json.found()
+	subproject('nlohmann_json')
+	json_header_dir = include_directories('subprojects/nlohmann_json/single_include')
+endif
+
+# Generate configuration header
+conf_data = configuration_data()
+conf_data.set('version', meson.project_version())
+conf_data.set('prefix', get_option('prefix'))
+conf_data.set('datadir', get_option('prefix') / get_option('datadir') / 'nwg-launchers')
+configure_file(
+	input : 'nwgconfig.h.in',
+	output : 'nwgconfig.h',
+	configuration : conf_data
+)
+
+if get_option('bar')
+	subdir('bar')
+endif
+
+if get_option('dmenu')
+	subdir('dmenu')
+endif
+
+if get_option('grid')
+	subdir('grid')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,3 @@
+option('bar', type: 'boolean', value: true, description: 'Build the bar app.')
+option('dmenu', type: 'boolean', value: true, description: 'Build the dmenu app.')
+option('grid', type: 'boolean', value: true, description: 'Build the grid app.')

--- a/nwgconfig.h.in
+++ b/nwgconfig.h.in
@@ -1,0 +1,3 @@
+#define VERSION_STR "@version@"
+#define INSTALL_PREFIX_STR "@prefix@"
+#define DATA_DIR_STR "@datadir@"

--- a/subprojects/nlohmann_json.wrap
+++ b/subprojects/nlohmann_json.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+url = https://github.com/nlohmann/json.git
+revision = develop
+depth = 1


### PR DESCRIPTION
~~Ok as promised I think I reproduced exactly the current Makefile configuration and installation paths, but this is not a common way to configure a build. There are some hardcoded paths that need to be removed like in the scripts that point to the /usr/lib directories. What if someone wanted to install it in their /usr/local/lib directory, or their system installs the libraries in the /usr/lib64 or /usr/lib/x86_64-linux-gnu directories. We can discuss this in an other issue, plz test.~~

Closes #30
Closes #36

**Changes**

- The meson system

- A generated config header that contains the installation paths,
so instead of hardcoding the paths we can use that.

- Install the app data inside a nwg-launchers directory so instead of
/usr/share/nwgbar and /usr/share/nwgdmenu we have
/usr/share/nwg-launchers/nwgbar and /usr/share/nwg-launchers/nwgdmenu.
It seems neater that way, but can be reversed if it is not wanted.

You can now change the prefix with meson setup builddir -Dprefix=/usr
and everything works.

Default prefix is /usr/local by default in meson.

The default style files are still copied to the user's config folder if
they do not exist - I didn't change that.

If something doesn't behave like the above, it is a bug I made.

If you need meson and ninja
sudo pip3 install meson ninja

Compile with:
meson setup builddir
meson compile -C builddir
sudo meson install -C builddir