### PR TITLE
wrapper scripts removed

### DIFF
--- a/bar/Makefile
+++ b/bar/Makefile
@@ -19,12 +19,8 @@ clean:
 
 install: all
 	mkdir -p ${DESTDIR}${PREFIX}/bin
-	cp -f bar.sh ${DESTDIR}${PREFIX}/bin/nwgbar
+	cp -f nwgbar ${DESTDIR}${PREFIX}/bin/nwgbar
 	chmod 755 ${DESTDIR}${PREFIX}/bin/nwgbar
-	
-	mkdir -p ${DESTDIR}${PREFIX}/lib/nwgbar
-	cp -f nwgbar ${DESTDIR}${PREFIX}/lib/nwgbar
-	chmod 755 ${DESTDIR}${PREFIX}/lib/nwgbar/nwgbar
 	
 	mkdir -p ${DESTDIR}${PREFIX}/share/nwgbar
 	cp -f style.css ${DESTDIR}${PREFIX}/share/nwgbar
@@ -33,5 +29,4 @@ install: all
 
 uninstall:
 	rm -f ${DESTDIR}${PREFIX}/bin/nwgbar
-	rm -rf ${DESTDIR}${PREFIX}/lib/nwgbar
 	rm -rf ${DESTDIR}${PREFIX}/share/nwgbar

--- a/bar/Makefile
+++ b/bar/Makefile
@@ -35,4 +35,3 @@ uninstall:
 	rm -f ${DESTDIR}${PREFIX}/bin/nwgbar
 	rm -rf ${DESTDIR}${PREFIX}/lib/nwgbar
 	rm -rf ${DESTDIR}${PREFIX}/share/nwgbar
-	rm -f /tmp/nwgbar.lock

--- a/bar/bar.sh
+++ b/bar/bar.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-cd /usr/lib/nwgbar
-exec ./nwgbar "$@"

--- a/bar/bar_tools.cpp
+++ b/bar/bar_tools.cpp
@@ -6,20 +6,6 @@
  * License: GPL3
  * */
 
-/* Try to lock the lock file
- * Thanks to chmike at https://stackoverflow.com/a/1643134
- * */
-int tryGetLock(char const *lockName) {
-    mode_t m = umask(0);
-    int fd = open(lockName, O_RDWR|O_CREAT, 0666);
-    umask( m );
-    if( fd >= 0 && flock(fd, LOCK_EX | LOCK_NB ) < 0) {
-        close(fd);
-        fd = -1;
-    }
-    return fd;
-}
-
 /*
  * Returns config dir
  * */

--- a/dmenu/Makefile
+++ b/dmenu/Makefile
@@ -36,4 +36,3 @@ uninstall:
 	rm -f ${DESTDIR}${PREFIX}/bin/nwgdmenu_run
 	rm -rf ${DESTDIR}${PREFIX}/lib/nwgdmenu
 	rm -rf ${DESTDIR}${PREFIX}/share/nwgdmenu
-	rm -f /tmp/nwgdmenu.lock

--- a/dmenu/Makefile
+++ b/dmenu/Makefile
@@ -19,20 +19,12 @@ clean:
 
 install: all
 	mkdir -p ${DESTDIR}${PREFIX}/bin
-	cp -f dmenu.sh ${DESTDIR}${PREFIX}/bin/nwgdmenu
+	cp -f nwgdmenu ${DESTDIR}${PREFIX}/bin/nwgdmenu
 	chmod 755 ${DESTDIR}${PREFIX}/bin/nwgdmenu
-	cp -f dmenu_run.sh ${DESTDIR}${PREFIX}/bin/nwgdmenu_run
-	chmod 755 ${DESTDIR}${PREFIX}/bin/nwgdmenu_run
-	
-	mkdir -p ${DESTDIR}${PREFIX}/lib/nwgdmenu
-	cp -f nwgdmenu ${DESTDIR}${PREFIX}/lib/nwgdmenu
-	chmod 755 ${DESTDIR}${PREFIX}/lib/nwgdmenu/nwgdmenu
 	
 	mkdir -p ${DESTDIR}${PREFIX}/share/nwgdmenu
 	cp -f style.css ${DESTDIR}${PREFIX}/share/nwgdmenu
 
 uninstall:
 	rm -f ${DESTDIR}${PREFIX}/bin/nwgdmenu
-	rm -f ${DESTDIR}${PREFIX}/bin/nwgdmenu_run
-	rm -rf ${DESTDIR}${PREFIX}/lib/nwgdmenu
 	rm -rf ${DESTDIR}${PREFIX}/share/nwgdmenu

--- a/dmenu/dmenu.sh
+++ b/dmenu/dmenu.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-cd /usr/lib/nwgdmenu
-exec ./nwgdmenu "$@"

--- a/dmenu/dmenu_run.sh
+++ b/dmenu/dmenu_run.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-cd /usr/lib/nwgdmenu
-exec echo -e | ./nwgdmenu "$@"

--- a/dmenu/dmenu_tools.cpp
+++ b/dmenu/dmenu_tools.cpp
@@ -6,20 +6,6 @@
  * License: GPL3
  * */
 
-/* Try to lock the lock file
- * Thanks to chmike at https://stackoverflow.com/a/1643134
- * */
-int tryGetLock(char const *lockName) {
-    mode_t m = umask( 0 );
-    int fd = open( lockName, O_RDWR|O_CREAT, 0666 );
-    umask( m );
-    if( fd >= 0 && flock( fd, LOCK_EX | LOCK_NB ) < 0 ) {
-        close( fd );
-        fd = -1;
-    }
-    return fd;
-}
-
 /*
  * Returns config dir
  * */

--- a/grid/Makefile
+++ b/grid/Makefile
@@ -19,12 +19,8 @@ clean:
 
 install: all
 	mkdir -p ${DESTDIR}${PREFIX}/bin
-	cp -f grid.sh ${DESTDIR}${PREFIX}/bin/nwggrid
+	cp -f nwggrid ${DESTDIR}${PREFIX}/bin/nwggrid
 	chmod 755 ${DESTDIR}${PREFIX}/bin/nwggrid
-	
-	mkdir -p ${DESTDIR}${PREFIX}/lib/nwggrid
-	cp -f nwggrid ${DESTDIR}${PREFIX}/lib/nwggrid
-	chmod 755 ${DESTDIR}${PREFIX}/lib/nwggrid/nwggrid
 	
 	mkdir -p ${DESTDIR}${PREFIX}/share/nwggrid
 	cp -f style.css ${DESTDIR}${PREFIX}/share/nwggrid
@@ -32,5 +28,4 @@ install: all
 
 uninstall:
 	rm -f ${DESTDIR}${PREFIX}/bin/nwggrid
-	rm -rf ${DESTDIR}${PREFIX}/lib/nwggrid
 	rm -rf ${DESTDIR}${PREFIX}/share/nwggrid

--- a/grid/Makefile
+++ b/grid/Makefile
@@ -34,4 +34,3 @@ uninstall:
 	rm -f ${DESTDIR}${PREFIX}/bin/nwggrid
 	rm -rf ${DESTDIR}${PREFIX}/lib/nwggrid
 	rm -rf ${DESTDIR}${PREFIX}/share/nwggrid
-	rm -f /tmp/nwggrid.lock

--- a/grid/grid.sh
+++ b/grid/grid.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-cd /usr/lib/nwggrid
-exec ./nwggrid "$@"

--- a/grid/grid_tools.cpp
+++ b/grid/grid_tools.cpp
@@ -6,20 +6,6 @@
  * License: GPL3
  * */
 
-/* Try to lock the lock file
- * Thanks to chmike at https://stackoverflow.com/a/1643134
- * */
-int tryGetLock(char const *lockName) {
-    mode_t m = umask( 0 );
-    int fd = open( lockName, O_RDWR|O_CREAT, 0666 );
-    umask( m );
-    if( fd >= 0 && flock( fd, LOCK_EX | LOCK_NB ) < 0 ) {
-        close( fd );
-        fd = -1;
-    }
-    return fd;
-}
-
 /*
  * Returns cache file path
  * */


### PR DESCRIPTION
1. No more scripts to launch commands placed in /usr/lib. All commands moved to the bin folder.
2. No need to use `nwgdmenu_run` script. `<some_command> | nwgdmenu` builds dmenu out of stdin input. The `nwgdmenu` command standalone builds the menu out of command found in $PATH, as primary `nwgdmenu_run` did.