### PR TITLE
grid: look for .desktop files under --prefix first

### DIFF
--- a/grid/grid_tools.cc
+++ b/grid/grid_tools.cc
@@ -88,8 +88,12 @@ void remove_and_save_pinned(std::string command) {
  * */
 std::vector<std::string> get_app_dirs() {
     std::string homedir = getenv("HOME");
-    std::vector<std::string> result = {homedir + "/.local/share/applications", "/usr/share/applications",
-        "/usr/local/share/applications"};
+    std::vector<std::string> result = {
+        homedir + "/.local/share/applications",
+        INSTALL_PREFIX_STR "/share/applications",
+        "/usr/share/applications",
+        "/usr/local/share/applications"
+    };
 
     auto xdg_data_dirs = getenv("XDG_DATA_DIRS");
     if (xdg_data_dirs != NULL) {


### PR DESCRIPTION
**nwggrid** hardcodes locations where system `.desktop` files are installed. When **nwggrid** is installed under non-default prefix (e.g., neither `/usr` nor `/usr/local` when using multiple packaging systems) default paths maybe unused. Let's add `${prefix}/share/applications`.

```
$ meson --prefix=/tmp/foo _build && meson compile -C _build && meson install -C _build
$ strings /tmp/foo/bin/nwggrid | fgrep /tmp/foo
/tmp/foo/share/nwg-launchers/nwggrid/icon-missing.svg
/tmp/foo/share/nwg-launchers/nwggrid/style.css
```
