### PR TITLE
Alternative pin/unpin implementation, faster parsing

### DIFF
--- a/bar/bar.cc
+++ b/bar/bar.cc
@@ -63,8 +63,6 @@ int main(int argc, char *argv[]) {
     }
     save_string_to_file(mypid, pid_file);
 
-    std::string lang ("");
-
     InputParser input(argc, argv);
     if(input.cmdOptionExists("-h")){
         std::cout << HELP_MESSAGE;

--- a/common/nwg_classes.cc
+++ b/common/nwg_classes.cc
@@ -72,15 +72,6 @@ void CommonWindow::check_screen() {
     _SUPPORTS_ALPHA = (bool)visual;
 }
 
-void CommonWindow::quit() {
-    auto toplevel = dynamic_cast<Gtk::Window*>(this->get_toplevel());
-    if (!toplevel) {
-        std::cerr << "ERROR: Toplevel widget is not a window\n";
-        std::exit(EXIT_FAILURE);
-    }
-    toplevel->get_application()->quit();
-}
-
 AppBox::AppBox() {
     this -> set_always_show_image(true);
 }

--- a/common/nwg_classes.h
+++ b/common/nwg_classes.h
@@ -38,8 +38,6 @@ class CommonWindow : public Gtk::Window {
         virtual ~CommonWindow();
 
         void check_screen();
-        void quit();
-
     protected:
         bool on_draw(const ::Cairo::RefPtr< ::Cairo::Context>& cr) override;
         void on_screen_changed(const Glib::RefPtr<Gdk::Screen>& previous_screen) override;

--- a/common/nwg_tools.cc
+++ b/common/nwg_tools.cc
@@ -260,11 +260,11 @@ void set_background(std::string_view string) {
             background.blue = ((rgba >> 8) & 0xff) / 255.0;
             background.alpha = ((rgba) & 0xff) / 255.0;
         } else {
-            std::cerr << "ERROR: invalid color value. Should be RRGGBB or RRGGBBAA";
+            std::cerr << "ERROR: invalid color value. Should be RRGGBB or RRGGBBAA\n";
         }
     }
     catch (...) {
-        std::cerr << "Error parsing RGB(A) value \n";
+        std::cerr << "Error parsing RGB(A) value\n";
     }
 }
 

--- a/common/nwg_tools.cc
+++ b/common/nwg_tools.cc
@@ -146,10 +146,11 @@ Gtk::Image* app_image(const Gtk::IconTheme& icon_theme, const std::string& icon)
 std::string get_locale() {
     std::string loc = getenv("LANG");
     if (!loc.empty()) {
-        if (loc.find("_") != std::string::npos) {
-            auto idx = loc.find_first_of("_");
-            return loc.substr(0, idx);
+        auto idx = loc.find_first_of("_");
+        if (idx != std::string::npos) {
+            loc.resize(idx);
         }
+        return loc;
     }
     return "en";
 }

--- a/common/nwg_tools.cc
+++ b/common/nwg_tools.cc
@@ -144,20 +144,14 @@ Gtk::Image* app_image(const Gtk::IconTheme& icon_theme, const std::string& icon)
  * Returns current locale
  * */
 std::string get_locale() {
-    std::string l {"en"};
-    if (getenv("LANG") != NULL) {
-        char* env_val = getenv("LANG");
-        std::string loc(env_val);
-        if (!loc.empty()) {
-            if (loc.find("_") != std::string::npos) {
-                int idx = loc.find_first_of("_");
-                l = loc.substr(0, idx);
-            } else {
-                l = loc;
-            }
+    std::string loc = getenv("LANG");
+    if (!loc.empty()) {
+        if (loc.find("_") != std::string::npos) {
+            auto idx = loc.find_first_of("_");
+            return loc.substr(0, idx);
         }
     }
-    return l;
+    return "en";
 }
 
 /*

--- a/grid/grid.cc
+++ b/grid/grid.cc
@@ -253,6 +253,7 @@ int main(int argc, char *argv[]) {
         std::cerr << "ERROR: Failed to load icon theme\n";
     }
     auto& icon_theme_ref = *icon_theme.get();
+    icon_theme_ref.add_resource_path(DATA_DIR_STR "/icon-missing.svg");
 
     if (std::filesystem::is_regular_file(css_file)) {
         provider->load_from_path(css_file);
@@ -262,7 +263,7 @@ int main(int argc, char *argv[]) {
         std::cout << "Using " << default_css_file << '\n';
     }
 
-    MainWindow window;
+    MainWindow window{ favourites.size(), pinned.size() };
 
     window.show();
 
@@ -289,174 +290,79 @@ int main(int argc, char *argv[]) {
         window.move(x, y);
     }
 
-    Gtk::Box outer_box(Gtk::ORIENTATION_VERTICAL);
-    outer_box.set_spacing(15);
-
-    // hbox for searchbox
-    Gtk::HBox hbox_header;
-
-    hbox_header.pack_start(window.searchbox, Gtk::PACK_EXPAND_PADDING);
-
-    outer_box.pack_start(hbox_header, Gtk::PACK_SHRINK, Gtk::PACK_EXPAND_PADDING);
-
-    Gtk::ScrolledWindow scrolled_window;
-    scrolled_window.set_propagate_natural_height(true);
-    scrolled_window.set_propagate_natural_width(true);
-    scrolled_window.set_policy(Gtk::POLICY_AUTOMATIC, Gtk::POLICY_ALWAYS);
-
-    /* Create buttons for all desktop entries */
-    for (auto& entry : desktop_entries) {
-        if (std::find(pinned.begin(), pinned.end(), entry.exec) == pinned.end()) {
-             auto& ab = window.all_boxes.emplace_back(std::move(entry.name),
-                                                      std::move(entry.exec),
-                                                      std::move(entry.comment),
-                                                      false);
-             Gtk::Image* image = app_image(icon_theme_ref, entry.icon);
-             ab.set_image_position(Gtk::POS_TOP);
-             ab.set_image(*image);
+    /* Create buttons for pinned entries */
+    for (auto& pin : pinned) {
+        auto find = [&pin](auto& container) {
+            return std::find_if(container.begin(), container.end(), [&pin](auto& e) {
+                return pin == e.exec;
+            });
+        };
+        auto iter = find(desktop_entries);
+        if (iter != desktop_entries.end()) {
+            auto& entry = *iter;
+            auto found = find(favourites) != favourites.end();
+            // 0 -> Common
+            // 1 -> Favorite
+            auto fav_tag = GridBox::FavTag{ found };
+            auto& ab = window.emplace_box(std::move(entry.name),
+                                          std::move(entry.exec),
+                                          std::move(entry.comment),
+                                          fav_tag,
+                                          GridBox::Pinned);
+            Gtk::Image* image = app_image(icon_theme_ref, entry.icon);
+            ab.set_image_position(Gtk::POS_TOP);
+            ab.set_image(*image);
         }
     }
-    window.label_desc.set_text(std::to_string(window.all_boxes.size()));
 
     /* Create buttons for favourites */
-    if (favs) {
-        for (auto& entry : favourites) {
-            for (auto& de : desktop_entries) {
-                if (de.exec == entry.exec) {
+    for (auto& entry : favourites) {
+        for (auto& de : desktop_entries) {
+            if (entry.exec == de.exec) {
 
-                    // avoid adding twice the same exec w/ another name
-                    bool already_added {false};
-                    for (auto& app_box : window.fav_boxes) {
-                        if (app_box.exec == de.exec) {
-                            already_added = true;
-                            break;
-                        }
-                    }
-                    if (already_added) {
-                        continue;
-                    }
+                // avoid adding twice the same exec w/ another name
+                //bool already_added {false};
+                //for (auto& app_box : window.fav_boxes) {
+                //    if (app_box.exec == de.exec) {
+                //        already_added = true;
+                //        break;
+                //    }
+                //}
+                //if (already_added) {
+                //    continue;                  // TODO: reimpl this
+                //}
 
-                    auto& ab = window.fav_boxes.emplace_back(std::move(de.name),
-                                                             std::move(de.exec),
-                                                             std::move(de.comment),
-                                                             false);
-                    
-                    Gtk::Image* image = app_image(icon_theme_ref, de.icon);
-                    ab.set_image_position(Gtk::POS_TOP);
-                    ab.set_image(*image);
-                }
-            }
-        }
-    }
-
-    /* Create buttons for pinned entries */
-    if (pins && pinned.size() > 0) {
-        for(auto& entry : desktop_entries) {
-            if (std::find(pinned.begin(), pinned.end(), entry.exec) != pinned.end()) {
-                auto& ab = window.pinned_boxes.emplace_back(std::move(entry.name),
-                                                            std::move(entry.exec),
-                                                            std::move(entry.comment),
-                                                            true);
-                Gtk::Image* image = app_image(icon_theme_ref, entry.icon);
+                auto& ab = window.emplace_box(std::move(de.name),
+                                              std::move(de.exec),
+                                              std::move(de.comment),
+                                              GridBox::Favorite, 
+                                              GridBox::Unpinned);
+                
+                Gtk::Image* image = app_image(icon_theme_ref, de.icon);
                 ab.set_image_position(Gtk::POS_TOP);
                 ab.set_image(*image);
             }
         }
     }
 
-    int column = 0;
-    int row = 0;
-    if (pins && pinned.size() > 0) {
-        window.pinned_grid.freeze_child_notify();
-        for (auto& box : window.pinned_boxes) {
-            window.pinned_grid.attach(box, column, row, 1, 1);
-            if (column < num_col - 1) {
-                column++;
-            } else {
-                column = 0;
-                row++;
-            }
-        }
-        window.pinned_grid.thaw_child_notify();
-    }
-
-    column = 0;
-    row = 0;
-    if (favs && favourites.size() > 0) {
-        window.favs_grid.freeze_child_notify();
-        for (auto& box : window.fav_boxes) {
-            window.favs_grid.attach(box, column, row, 1, 1);
-            if (column < num_col - 1) {
-                column++;
-            } else {
-                column = 0;
-                row++;
-            }
-        }
-        window.favs_grid.thaw_child_notify();
-    }
-
-    column = 0;
-    row = 0;
-    for (auto& box : window.all_boxes) {
-        window.apps_grid.freeze_child_notify();
-        window.apps_grid.attach(box, column, row, 1, 1);
-        if (column < num_col - 1) {
-            column++;
-        } else {
-            column = 0;
-            row++;
-        }
-        window.apps_grid.thaw_child_notify();
-    }
-
-    Gtk::VBox inner_vbox;
-
-    Gtk::HBox pinned_hbox;
-    pinned_hbox.pack_start(window.pinned_grid, true, false, 0);
-    inner_vbox.pack_start(pinned_hbox, false, false, 5);
-    if (pins && pinned.size() > 0) {
-        inner_vbox.pack_start(window.separator1, false, true, 0);
-    }
-
-    Gtk::HBox favs_hbox;
-    favs_hbox.pack_start(window.favs_grid, true, false, 0);
-    inner_vbox.pack_start(favs_hbox, false, false, 5);
-    if (favs && favourites.size() > 0) {
-        inner_vbox.pack_start(window.separator, false, true, 0);
-    }
-
-    Gtk::HBox apps_hbox;
-    apps_hbox.pack_start(window.apps_grid, Gtk::PACK_EXPAND_PADDING);
-    inner_vbox.pack_start(apps_hbox, true, true, 0);
-
-    scrolled_window.add(inner_vbox);
-
-    outer_box.pack_start(scrolled_window, Gtk::PACK_EXPAND_WIDGET);
-    scrolled_window.show_all_children();
-
-    outer_box.pack_start(window.label_desc, Gtk::PACK_SHRINK);
-
-    window.add(outer_box);
-    window.show_all_children();
-
-    // Set keyboard focus to the first visible button
-    if (favs && favourites.size() > 0) {
-        auto* first = window.favs_grid.get_child_at(0, 0);
-        if (first) {
-            first -> grab_focus();
-        }
-    } else if (pins && pinned.size() > 0) {
-        auto* first = window.pinned_grid.get_child_at(0, 0);
-        if (first) {
-            first -> grab_focus();
-        }
-    } else {
-        auto* first = window.apps_grid.get_child_at(0, 0);
-        if (first) {
-            first -> grab_focus();
+    /* Create buttons for the rest of entries */
+    for (auto& entry : desktop_entries) {
+        // if it's empty, it was probably moved from during the previous steps
+        // there should be some better way, but it works
+        if (!entry.exec.empty()) {
+             auto& ab = window.emplace_box(std::move(entry.name),
+                                           std::move(entry.exec),
+                                           std::move(entry.comment),
+                                           GridBox::Common,
+                                           GridBox::Unpinned);
+             Gtk::Image* image = app_image(icon_theme_ref, entry.icon);
+             ab.set_image_position(Gtk::POS_TOP);
+             ab.set_image(*image);
         }
     }
+
+    
+    window.build_grids();
 
     gettimeofday(&tp, NULL);
     long int end_ms = tp.tv_sec * 1000 + tp.tv_usec / 1000;

--- a/grid/grid.cc
+++ b/grid/grid.cc
@@ -22,7 +22,6 @@ RGBA background = {0.0, 0.0, 0.0, 0.9};
 std::string wm {""};            // detected or forced window manager name
 
 int num_col = 6;                // number of grid columns
-Gtk::Label *description;
 
 std::string pinned_file {};
 std::vector<std::string> pinned;    // list of commands of pinned icons
@@ -314,18 +313,10 @@ int main(int argc, char *argv[]) {
     for (auto& entry : favourites) {
         for (auto& de : desktop_entries) {
             if (entry.exec == de.exec) {
-
-                // avoid adding twice the same exec w/ another name
-                //bool already_added {false};
-                //for (auto& app_box : window.fav_boxes) {
-                //    if (app_box.exec == de.exec) {
-                //        already_added = true;
-                //        break;
-                //    }
-                //}
-                //if (already_added) {
-                //    continue;                  // TODO: reimpl this
-                //}
+                auto already_added = window.has_fav_with_exec(entry.exec);
+                if (already_added) {
+                    continue;
+                }
 
                 auto& ab = window.emplace_box(std::move(de.name),
                                               std::move(de.exec),

--- a/grid/grid.cc
+++ b/grid/grid.cc
@@ -257,7 +257,7 @@ int main(int argc, char *argv[]) {
         std::cout << "Using " << default_css_file << '\n';
     }
 
-    MainWindow window{ favourites.size(), pinned.size() };
+    MainWindow window;
 
     window.show();
 

--- a/grid/grid.h
+++ b/grid/grid.h
@@ -66,9 +66,9 @@ class MainWindow : public CommonWindow {
 
         Gtk::SearchEntry searchbox;              // Search apps
         Gtk::Label description;                  // To display .desktop entry Comment field at the bottom
-        Gtk::Grid apps_grid;                     // All application buttons grid
-        Gtk::Grid favs_grid;                     // Favourites grid above
-        Gtk::Grid pinned_grid;                   // Pinned entries grid above
+        Gtk::FlowBox apps_grid;                  // All application buttons grid
+        Gtk::FlowBox favs_grid;                  // Favourites grid above
+        Gtk::FlowBox pinned_grid;                // Pinned entries grid above
         Gtk::Separator separator;                // between favs and all apps
         Gtk::Separator separator1;               // below pinned
         Gtk::VBox outer_vbox;

--- a/grid/grid.h
+++ b/grid/grid.h
@@ -60,17 +60,11 @@ public:
     PinTag pinned;
 };
 
-class GridSearch : public Gtk::SearchEntry {
-public:
-    GridSearch();
-    void prepare_to_insertion();
-};
-
 class MainWindow : public CommonWindow {
     public:
         MainWindow(size_t, size_t);
 
-        GridSearch searchbox;                    // Search apps
+        Gtk::SearchEntry searchbox;              // Search apps
         Gtk::Label description;                  // To display .desktop entry Comment field at the bottom
         Gtk::Grid apps_grid;                     // All application buttons grid
         Gtk::Grid favs_grid;                     // Favourites grid above
@@ -86,7 +80,7 @@ class MainWindow : public CommonWindow {
         Gtk::ScrolledWindow scrolled_window;
 
         template<typename ... Args>
-        GridBox& emplace_box(Args&& ... args);  // emplace box
+        GridBox& emplace_box(Args&& ... args);   // emplace box
 
         void build_grids();
         void toggle_pinned(GridBox& box);

--- a/grid/grid.h
+++ b/grid/grid.h
@@ -93,6 +93,7 @@ class MainWindow : public CommonWindow {
         std::vector<GridBox*> fav_boxes {};      // attached to favs_grid
         std::vector<GridBox*> pinned_boxes {};   // attached to pinned_grid
         bool pins_changed = false;
+        bool is_filtered = false;
 
         void focus_first_box();
         void filter_view();

--- a/grid/grid.h
+++ b/grid/grid.h
@@ -103,10 +103,8 @@ class MainWindow : public CommonWindow {
         std::vector<GridBox*> pinned_boxes {};   // attached to pinned_grid
         bool pins_changed = false;
 
-        void clear_grids();
         void focus_first_box();
         void filter_view();
-        void rebuild_grid(bool filtered);
 };
 
 template<typename ... Args>

--- a/grid/grid.h
+++ b/grid/grid.h
@@ -57,7 +57,7 @@ public:
 
 class MainWindow : public CommonWindow {
     public:
-        MainWindow(size_t, size_t);
+        MainWindow();
 
         Gtk::SearchEntry searchbox;              // Search apps
         Gtk::Label description;                  // To display .desktop entry Comment field at the bottom
@@ -96,6 +96,7 @@ class MainWindow : public CommonWindow {
 
         void focus_first_box();
         void filter_view();
+        void refresh_separators();
 };
 
 template <typename ... Args>

--- a/grid/grid.h
+++ b/grid/grid.h
@@ -31,7 +31,6 @@ extern double opacity;
 extern std::string wm;
 
 extern int num_col;
-extern Gtk::Label *description;
 
 extern std::string pinned_file;
 extern std::vector<std::string> pinned;
@@ -40,14 +39,25 @@ extern std::string cache_file;
 
 class GridBox : public AppBox {
 public:
-    /* name, exec, comment, pinned */
-    GridBox(Glib::ustring, Glib::ustring, Glib::ustring, bool);
+    enum FavTag: bool {
+        Common = 0,
+        Favorite = 1,
+    };
+    enum PinTag: bool {
+        Unpinned = 0,
+        Pinned = 1,
+    };
+
+    /* name, exec, comment, favorite, pinned */
+    GridBox(Glib::ustring, Glib::ustring, Glib::ustring, FavTag, PinTag);
     bool on_button_press_event(GdkEventButton*) override;
     bool on_focus_in_event(GdkEventFocus*) override;
     void on_enter() override;
     void on_activate() override;
 
-    bool pinned;
+
+    FavTag favorite;
+    PinTag pinned;
 };
 
 class GridSearch : public Gtk::SearchEntry {
@@ -58,26 +68,59 @@ public:
 
 class MainWindow : public CommonWindow {
     public:
-        MainWindow();
+        MainWindow(size_t, size_t);
 
-        GridSearch searchbox;                   // Search apps
-        Gtk::Label label_desc;                  // To display .desktop entry Comment field at the bottom
-        Gtk::Grid apps_grid;                    // All application buttons grid
-        Gtk::Grid favs_grid;                    // Favourites grid above
-        Gtk::Grid pinned_grid;                  // Pinned entries grid above
-        Gtk::Separator separator;               // between favs and all apps
-        Gtk::Separator separator1;              // below pinned
-        std::list<GridBox> all_boxes {};        // attached to apps_grid unfiltered view
-        std::list<GridBox*> filtered_boxes {};  // attached to apps_grid filtered view
-        std::list<GridBox> fav_boxes {};        // attached to favs_grid
-        std::list<GridBox> pinned_boxes {};     // attached to pinned_grid
+        GridSearch searchbox;                    // Search apps
+        Gtk::Label description;                  // To display .desktop entry Comment field at the bottom
+        Gtk::Grid apps_grid;                     // All application buttons grid
+        Gtk::Grid favs_grid;                     // Favourites grid above
+        Gtk::Grid pinned_grid;                   // Pinned entries grid above
+        Gtk::Separator separator;                // between favs and all apps
+        Gtk::Separator separator1;               // below pinned
+        Gtk::VBox outer_vbox;
+        Gtk::VBox inner_vbox;
+        Gtk::HBox hbox_header;
+        Gtk::HBox pinned_hbox;
+        Gtk::HBox favs_hbox;
+        Gtk::HBox apps_hbox;
+        Gtk::ScrolledWindow scrolled_window;
 
-    private:
+        template<typename ... Args>
+        GridBox& emplace_box(Args&& ... args);  // emplace box
+
+        void build_grids();
+        void toggle_pinned(GridBox& box);
+        void set_description(const Glib::ustring&);
+    protected:
         //Override default signal handler:
-        bool on_key_press_event(GdkEventKey* event) override;
+        bool on_key_press_event(GdkEventKey*) override;
+        bool on_delete_event(GdkEventAny*) override;
+    private:
+        std::list<GridBox> all_boxes {};         // stores all applications buttons
+        std::vector<GridBox*> apps_boxes {};     // boxes attached to apps_grid
+        std::vector<GridBox*> filtered_boxes {}; // filtered boxes from
+        std::vector<GridBox*> fav_boxes {};      // attached to favs_grid
+        std::vector<GridBox*> pinned_boxes {};   // attached to pinned_grid
+        bool pins_changed = false;
+
+        void clear_grids();
+        void focus_first_box();
         void filter_view();
         void rebuild_grid(bool filtered);
 };
+
+template<typename ... Args>
+GridBox& MainWindow::emplace_box(Args&& ... args) {
+    auto& ab = this -> all_boxes.emplace_back(std::forward<Args>(args)...);
+    if (ab.pinned) {
+        pinned_boxes.push_back(&ab);
+    } else if (ab.favorite) {
+        fav_boxes.push_back(&ab);
+    } else {
+        apps_boxes.push_back(&ab);
+    }
+    return ab;
+}
 
 struct CacheEntry {
     std::string exec;
@@ -90,8 +133,6 @@ struct CacheEntry {
  * */
 std::string get_cache_path(void);
 std::string get_pinned_path(void);
-void add_and_save_pinned(const std::string&);
-void remove_and_save_pinned(const std::string&);
 std::vector<std::string> get_app_dirs(void);
 std::vector<std::string> list_entries(const std::vector<std::string>&);
 DesktopEntry desktop_entry(std::string&&, const std::string&);

--- a/grid/grid.h
+++ b/grid/grid.h
@@ -84,7 +84,7 @@ class MainWindow : public CommonWindow {
         //Override default signal handler:
         bool on_key_press_event(GdkEventKey*) override;
         bool on_delete_event(GdkEventAny*) override;
-        bool on_button_press_event(GdkEventButton* event) override;
+        bool on_button_press_event(GdkEventButton*) override;
     private:
         std::list<GridBox> all_boxes {};         // stores all applications buttons
         std::vector<GridBox*> apps_boxes {};     // boxes attached to apps_grid

--- a/grid/grid.h
+++ b/grid/grid.h
@@ -74,9 +74,10 @@ class MainWindow : public CommonWindow {
         Gtk::HBox apps_hbox;
         Gtk::ScrolledWindow scrolled_window;
 
-        template<typename ... Args>
-        GridBox& emplace_box(Args&& ... args);   // emplace box
+        template <typename ... Args>
+        GridBox& emplace_box(Args&& ... args);      // emplace box
 
+        bool has_fav_with_exec(const std::string&) const;
         void build_grids();
         void toggle_pinned(GridBox& box);
         void set_description(const Glib::ustring&);
@@ -97,7 +98,7 @@ class MainWindow : public CommonWindow {
         void filter_view();
 };
 
-template<typename ... Args>
+template <typename ... Args>
 GridBox& MainWindow::emplace_box(Args&& ... args) {
     auto& ab = this -> all_boxes.emplace_back(std::forward<Args>(args)...);
     if (ab.pinned) {

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -332,8 +332,8 @@ void GridBox::on_enter() {
 }
 
 void GridBox::on_activate() {
-    exec.append(" &");
-    std::system(exec.data());
+    auto cmd = exec + " &";
+    std::system(cmd.data());
     auto toplevel = dynamic_cast<MainWindow*>(this->get_toplevel());
     toplevel->close();
 }

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -267,6 +267,11 @@ bool MainWindow::on_delete_event(GdkEventAny* event) {
     return CommonWindow::on_delete_event(event);
 }
 
+bool MainWindow::has_fav_with_exec(const std::string& exec) const {
+    auto pred = [&exec](auto* b) { return exec == b->exec; };
+    return std::find_if(fav_boxes.begin(), fav_boxes.end(), pred) != fav_boxes.end();
+}
+
 // This constructor is not needed since C++20
 GridBox::GridBox(Glib::ustring name, Glib::ustring exec, Glib::ustring comment, GridBox::FavTag fav, GridBox::PinTag pinned)
  : AppBox(std::move(name), std::move(exec), std::move(comment)), favorite(fav), pinned(pinned) {}

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -17,7 +17,9 @@
 #include "nwg_tools.h"
 #include "grid.h"
 
-MainWindow::MainWindow(): CommonWindow("~nwggrid", "~nwggrid") {
+MainWindow::MainWindow(size_t fav_size, size_t pinned_size)
+ : CommonWindow("~nwggrid", "~nwggrid")
+{
     searchbox
         .signal_search_changed()
         .connect(sigc::mem_fun(*this, &MainWindow::filter_view));
@@ -30,9 +32,8 @@ MainWindow::MainWindow(): CommonWindow("~nwggrid", "~nwggrid") {
     pinned_grid.set_column_spacing(5);
     pinned_grid.set_row_spacing(5);
     pinned_grid.set_column_homogeneous(true);
-    label_desc.set_text("");
-    label_desc.set_name("description");
-    description = &label_desc;
+    description.set_text("");
+    description.set_name("description");
     separator.set_orientation(Gtk::ORIENTATION_HORIZONTAL);
     separator.set_name("separator");
     separator1.set_orientation(Gtk::ORIENTATION_HORIZONTAL);
@@ -47,13 +48,45 @@ MainWindow::MainWindow(): CommonWindow("~nwggrid", "~nwggrid") {
         set_type_hint(Gdk::WINDOW_TYPE_HINT_SPLASHSCREEN);
         set_decorated(false);
     }
+    outer_vbox.set_spacing(15);
+    hbox_header.pack_start(searchbox, Gtk::PACK_EXPAND_PADDING);
+    outer_vbox.pack_start(hbox_header, Gtk::PACK_SHRINK, Gtk::PACK_EXPAND_PADDING);
+
+    scrolled_window.set_propagate_natural_height(true);
+    scrolled_window.set_propagate_natural_width(true);
+    scrolled_window.set_policy(Gtk::POLICY_AUTOMATIC, Gtk::POLICY_ALWAYS);
+    scrolled_window.add(inner_vbox);
+
+    pinned_hbox.pack_start(pinned_grid, true, false, 0);
+    inner_vbox.pack_start(pinned_hbox, false, false, 5);
+    if (pins && pinned_size > 0) {
+        inner_vbox.pack_start(separator1, false, true, 0);
+    }
+    
+    favs_hbox.pack_start(favs_grid, true, false, 0);
+    inner_vbox.pack_start(favs_hbox, false, false, 5);
+    // if favs disabled, fav_size == 0
+    if (fav_size > 0) {
+        inner_vbox.pack_start(separator, false, true, 0);
+    }
+
+    apps_hbox.pack_start(apps_grid, Gtk::PACK_EXPAND_PADDING);
+    inner_vbox.pack_start(apps_hbox, true, true, 0);
+
+    outer_vbox.pack_start(scrolled_window, Gtk::PACK_EXPAND_WIDGET);
+    scrolled_window.show_all_children();
+
+    outer_vbox.pack_start(description, Gtk::PACK_SHRINK);
+    
+    this -> add(outer_vbox);
+    this -> show_all_children();
 }
 
 bool MainWindow::on_key_press_event(GdkEventKey* key_event) {
     auto key_val = key_event -> keyval;
     switch (key_val) {
         case GDK_KEY_Escape:
-            this->quit();
+            this->close();
             break;
         case GDK_KEY_Delete:
             this -> searchbox.set_text("");
@@ -83,106 +116,252 @@ bool MainWindow::on_key_press_event(GdkEventKey* key_event) {
 
 void MainWindow::filter_view() {
     auto search_phrase = searchbox.get_text();
-    if (search_phrase.size() > 0) {
-        this -> filtered_boxes.clear();
-
+    auto filtered = search_phrase.size() > 0;
+    if (filtered) {
         auto phrase = search_phrase.casefold();
-        for (auto& box : this -> all_boxes) {
-            if (box.name.casefold().find(phrase) != Glib::ustring::npos ||
-                box.exec.casefold().find(phrase) != Glib::ustring::npos ||
-                box.comment.casefold().find(phrase) != Glib::ustring::npos)
-            {
-                this -> filtered_boxes.emplace_back(&box);
+        auto matches = [&phrase](auto& str) {
+            return str.casefold().find(phrase) != Glib::ustring::npos;
+        };
+
+        this -> filtered_boxes.clear();
+        for (auto& box : this -> apps_boxes) {
+            if (matches(box->name) || matches(box->exec) || matches(box->comment)) {
+                this -> filtered_boxes.emplace_back(box);
             }
         }
         this -> favs_grid.hide();
         this -> separator.hide();
-        this -> rebuild_grid(true);
     } else {
         this -> favs_grid.show();
         this -> separator.show();
-        this -> rebuild_grid(false);
     }
+    this -> rebuild_grid(filtered);
 }
 
-void MainWindow::rebuild_grid(bool filtered) {
-    int column = 0;
-    int row = 0;
-
+void MainWindow::clear_grids() {
+    this -> pinned_grid.freeze_child_notify();
+    this -> favs_grid.freeze_child_notify();
     this -> apps_grid.freeze_child_notify();
-    for (Gtk::Widget *widget : this -> apps_grid.get_children()) {
-        this -> apps_grid.remove(*widget);
-        widget -> unset_state_flags(Gtk::STATE_FLAG_PRELIGHT);
-    }
-    int cnt = 0;
-    if (filtered) {
-        for (auto& box : this -> filtered_boxes) {
-            this -> apps_grid.attach(*box, column, row, 1, 1);
-            if (column < num_col - 1) {
-                column++;
-            } else {
-                column = 0;
-                row++;
-            }
-            cnt++;
-        }
-        // Set keyboard focus to the first visible button
-        if (this -> fav_boxes.size() > 0) {
-            fav_boxes.front().grab_focus();
-        }
-    } else {
-        for (auto& box : this -> all_boxes) {
-            this -> apps_grid.attach(box, column, row, 1, 1);
-            if (column < num_col - 1) {
-                column++;
-            } else {
-                column = 0;
-                row++;
-            }
-            cnt++;
-        }
-        // Set keyboard focus to the first visible button
-        if (this -> all_boxes.size() > 0) {
-            all_boxes.front().grab_focus();
-        }
-    }
+
+    auto clear_grid = [](auto& grid) {
+        grid.foreach([&grid](auto& child) {
+            grid.remove(child);
+        });
+    };
+    clear_grid(this -> pinned_grid);
+    clear_grid(this -> favs_grid);
+    clear_grid(this -> apps_grid);
+    
+    this -> pinned_grid.thaw_child_notify();
+    this -> favs_grid.thaw_child_notify();
     this -> apps_grid.thaw_child_notify();
 }
 
-GridBox::GridBox(Glib::ustring name, Glib::ustring exec, Glib::ustring comment, bool pinned)
- : AppBox(std::move(name), std::move(exec), std::move(comment)), pinned(pinned) {}
-
-bool GridBox::on_button_press_event(GdkEventButton* event) {
-    int clicks = 0;
-    try {
-        clicks = cache[exec];
-        clicks++;
-    } catch(...) {
-        clicks = 1;
+inline auto advance = [](auto& x, auto& y) {
+    x++;
+    if (x == num_col) {
+        x = 0;
+        y++;
     }
-    cache[exec] = clicks;
-    save_json(cache, cache_file);    
+};
 
-    if (pins && event->button == 3) {
-        if (pinned) {
-            remove_and_save_pinned(exec);
-        } else {
-            add_and_save_pinned(exec);
+// fills empty `grid` with elements from `container` respecting `num_col` global variable
+inline auto build_grid = [](auto& grid, auto& container) {
+    int x = 0;
+    int y = 0;
+    for (auto* child : container) {
+        grid.attach(*child, x, y, 1, 1);
+        advance(x, y);
+    }
+};
+
+// shifts elements of `grid` from `x_`, `y_` to `x__`, `y__` respecting `num_col` global variable,
+// effectively filling the hole created by removing an element
+inline auto fill_hole = [](auto x_, auto y_, auto& grid, auto x__, auto y__) {
+    auto x = x_;
+    auto y = y_;
+
+    advance(x, y);
+    advance(x__, y__);
+
+    while (x != x__ || y != y__) {
+        auto child = grid.get_child_at(x, y);
+        if (child) {
+            grid.child_property_left_attach(*child).set_value(x_);
+            grid.child_property_top_attach(*child).set_value(y_);
+            advance(x_, y_);
+        }
+        advance(x, y);
+    }
+};
+
+void MainWindow::build_grids() {
+    this -> pinned_grid.freeze_child_notify();
+    this -> favs_grid.freeze_child_notify();
+    this -> apps_grid.freeze_child_notify();
+
+    build_grid(this->pinned_grid, this->pinned_boxes);
+    build_grid(this->favs_grid, this->fav_boxes);
+    build_grid(this->apps_grid, this->apps_boxes);
+
+    this -> focus_first_box();
+
+    this -> pinned_grid.show_all_children();
+    this -> favs_grid.show_all_children();
+    this -> apps_grid.show_all_children();
+
+    this -> pinned_grid.thaw_child_notify();
+    this -> favs_grid.thaw_child_notify();
+    this -> apps_grid.thaw_child_notify();
+
+    this -> set_description(std::to_string(apps_boxes.size()));
+}
+
+void MainWindow::rebuild_grid(bool filtered) {
+    auto& grid = this->apps_grid;
+    auto* container = &this->apps_boxes;
+    if (filtered) {
+        container = &this->filtered_boxes;
+    }
+    grid.freeze_child_notify();
+    grid.foreach([&grid](auto& child) {
+        grid.remove(child);
+        child.unset_state_flags(Gtk::STATE_FLAG_PRELIGHT);
+    });
+    build_grid(grid, *container);
+    this -> focus_first_box();
+    grid.thaw_child_notify();
+}
+
+void MainWindow::focus_first_box() {
+    auto containers = { &filtered_boxes, &pinned_boxes, &fav_boxes, &apps_boxes };
+    for (auto container : containers) {
+        if (container->size() > 0) {
+            container->front()->grab_focus();
+            return;
         }
     }
-    this -> activate();
-    return false;
+}
+
+void MainWindow::set_description(const Glib::ustring& text) {
+    this->description.set_text(text);
+}
+
+void MainWindow::toggle_pinned(GridBox& box) {
+    // pins changed, we'll need to update the cache
+    this->pins_changed = true;
+
+    // disable prelight
+    box.unset_state_flags(Gtk::STATE_FLAG_PRELIGHT);
+
+    auto is_pinned = box.pinned == GridBox::Pinned;
+    box.pinned = GridBox::PinTag{ !is_pinned };
+
+    // init just to use type deduction
+    auto* from_grid = &this->apps_grid;
+    auto* from = &this->apps_boxes;
+
+    // actual initialization here
+    switch (box.favorite) {
+        case GridBox::Common:
+            from = &this->apps_boxes;
+            from_grid = &this->apps_grid;
+            break;
+        case GridBox::Favorite:
+            from = &this->fav_boxes;
+            from_grid = &this->favs_grid;
+            break;
+    }
+    auto* to = &this->pinned_boxes;
+    auto* to_grid = &this->pinned_grid;
+    if (is_pinned) {
+        std::swap(from, to);
+        std::swap(from_grid, to_grid);
+    }
+
+    // now `to` is the container we want to move `box` to from `from` :^)
+    // and `from_grid` is where we move to `to_grid` from
+    std::remove(from->begin(), from->end(), &box);
+
+    auto x = from_grid->child_property_left_attach(box).get_value();
+    auto y = from_grid->child_property_top_attach(box).get_value();
+
+    // `from` is not empty, it contains atleast the widget we want to remove
+    auto last = from->back();
+    auto x_ = from_grid->child_property_left_attach(*last).get_value();
+    auto y_ = from_grid->child_property_top_attach(*last).get_value();
+
+    decltype(x_) xnew = 0;
+    decltype(y_) ynew = 0;
+
+    if (to->size() > 0) {
+        auto last = to->back();
+        xnew = to_grid->child_property_left_attach(*last).get_value();
+        ynew = to_grid->child_property_top_attach(*last).get_value();
+        advance(xnew, ynew);
+    }
+
+    if (x > x_ && y > y_) {
+        std::cerr << "ERROR: Critical failure -- failed to retrieve box coordinates\n";
+        std::abort();
+    }
+    from_grid->freeze_child_notify();    
+    from_grid->remove(box);
+    fill_hole(x, y, *from_grid, x_, y_);
+    from_grid->thaw_child_notify();    
+
+    to->push_back(&box);
+    to_grid->attach(box, xnew, ynew, 1, 1);
+}
+
+/*
+ * Saves pinned cache file
+ * */
+bool MainWindow::on_delete_event(GdkEventAny* event) {
+    if (this->pins_changed) {
+        std::ofstream out_file(pinned_file);
+        for (auto pin : this->pinned_boxes) {
+            out_file << pin->exec << '\n';
+        }
+    }
+    return CommonWindow::on_delete_event(event);
+}
+
+// This constructor is not needed since C++20
+GridBox::GridBox(Glib::ustring name, Glib::ustring exec, Glib::ustring comment, GridBox::FavTag fav, GridBox::PinTag pinned)
+ : AppBox(std::move(name), std::move(exec), std::move(comment)), favorite(fav), pinned(pinned) {}
+
+bool GridBox::on_button_press_event(GdkEventButton* event) {
+    if (pins && event->button == 3) {
+        auto toplevel = dynamic_cast<MainWindow*>(this -> get_toplevel());
+        toplevel->toggle_pinned(*this);
+    } else {
+        int clicks = 0;
+        try {
+            clicks = cache[exec];
+            clicks++;
+        } catch(...) {
+            clicks = 1;
+        }
+        cache[exec] = clicks;
+        save_json(cache, cache_file);    
+
+        this -> activate();
+    }
+    return AppBox::on_button_press_event(event);
 }
 
 bool GridBox::on_focus_in_event(GdkEventFocus* event) {
     (void) event; // suppress warning
 
-    description -> set_text(comment);
+    auto toplevel = dynamic_cast<MainWindow*>(this->get_toplevel());
+    toplevel->set_description(comment);
     return true;
 }
 
 void GridBox::on_enter() {
-    description -> set_text(comment);
+    auto toplevel = dynamic_cast<MainWindow*>(this->get_toplevel());
+    toplevel->set_description(comment);
     return AppBox::on_enter();
 }
 
@@ -190,7 +369,7 @@ void GridBox::on_activate() {
     exec.append(" &");
     std::system(exec.data());
     auto toplevel = dynamic_cast<MainWindow*>(this->get_toplevel());
-    toplevel->quit();
+    toplevel->close();
 }
 
 GridSearch::GridSearch() {

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -23,7 +23,7 @@ int by_name(Gtk::FlowBoxChild* a_, Gtk::FlowBoxChild* b_) {
     return a->name.compare(b->name);
 }
 
-MainWindow::MainWindow(size_t fav_size, size_t pinned_size)
+MainWindow::MainWindow()
  : CommonWindow("~nwggrid", "~nwggrid")
 {
     searchbox
@@ -83,16 +83,11 @@ MainWindow::MainWindow(size_t fav_size, size_t pinned_size)
 
     pinned_hbox.pack_start(pinned_grid, Gtk::PACK_EXPAND_WIDGET, 0);
     inner_vbox.pack_start(pinned_hbox, Gtk::PACK_EXPAND_PADDING, 5);
-    if (pins && pinned_size > 0) {
-        inner_vbox.pack_start(separator1, false, true, 0);
-    }
+    inner_vbox.pack_start(separator1, false, true, 0);
     
     favs_hbox.pack_start(favs_grid, true, false, 0);
     inner_vbox.pack_start(favs_hbox, false, false, 5);
-    // if favs disabled, fav_size == 0
-    if (fav_size > 0) {
-        inner_vbox.pack_start(separator, false, true, 0);
-    }
+    inner_vbox.pack_start(separator, false, true, 0);
 
     apps_hbox.pack_start(apps_grid, Gtk::PACK_EXPAND_PADDING);
     inner_vbox.pack_start(apps_hbox, true, true, 0);
@@ -155,14 +150,29 @@ void MainWindow::filter_view() {
     auto filtered = search_phrase.size() > 0;
     if (filtered) {
         this -> favs_grid.hide();
-        this -> separator.hide();
     } else {
         this -> favs_grid.show();
-        this -> separator.show();
     }
     this -> apps_grid.invalidate_filter();
     this -> focus_first_box();
     apps_grid.thaw_child_notify();
+}
+
+void MainWindow::refresh_separators() {
+    auto empty = 0;
+    empty += pinned_boxes.empty();
+    empty += fav_boxes.empty() && favs_grid.get_visible();
+    empty += apps_boxes.empty();
+    if (empty <= 1) {
+        separator.show();
+    } else {
+        separator.hide();
+    }
+    if (empty == 0) {
+        separator1.show();
+    } else {
+        separator1.hide();
+    }
 }
 
 /* In order to keep Gtk FlowBox content properly haligned, we have to maintain
@@ -202,6 +212,7 @@ void MainWindow::build_grids() {
     this -> apps_grid.thaw_child_notify();
 
     this -> set_description(std::to_string(apps_boxes.size()));
+    this -> refresh_separators();
 }
 
 void MainWindow::focus_first_box() {
@@ -254,6 +265,7 @@ void MainWindow::toggle_pinned(GridBox& box) {
     // but its parent, FlowBoxChild is
     // so we need to reparent FlowBoxChild, not the box itself
     box.get_parent()->reparent(*to_grid);
+    this->refresh_separators();
 }
 
 /*

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -44,7 +44,6 @@ MainWindow::MainWindow()
     setup_grid(favs_grid);
     setup_grid(pinned_grid);
     apps_grid.set_sort_func(&by_name);
-    favs_grid.set_sort_func(&by_name);
 
     description.set_text("");
     description.set_name("description");
@@ -219,7 +218,7 @@ void MainWindow::build_grids() {
     this -> favs_grid.thaw_child_notify();
     this -> apps_grid.thaw_child_notify();
 
-    this -> set_description(std::to_string(apps_boxes.size()));
+    this -> focus_first_box();
     this -> refresh_separators();
 }
 

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -171,7 +171,9 @@ void MainWindow::filter_view() {
 inline auto refresh_max_children_per_line = [](auto& flowbox, auto& container) {
     auto size = container.size();
     decltype(size) cols = num_col;
-    flowbox.set_max_children_per_line(std::min(size, cols));
+    if (auto min = std::min(cols, size)) {
+        flowbox.set_max_children_per_line(std::min(size, cols));
+    }
 };
 
 void MainWindow::build_grids() {

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -168,7 +168,6 @@ void MainWindow::filter_view() {
     filtered_boxes.clear();
     apps_grid.freeze_child_notify();
     if (is_filtered) {
-        favs_grid.hide();
         auto phrase = search_phrase.casefold();
         auto matches = [&phrase](auto& str) {
             return str.casefold().find(phrase) != Glib::ustring::npos;
@@ -181,7 +180,6 @@ void MainWindow::filter_view() {
         clean_grid(apps_grid);
         build_grid(apps_grid, filtered_boxes);
     } else {
-        favs_grid.show();
         clean_grid(apps_grid);
         build_grid(apps_grid, apps_boxes);
     }
@@ -193,7 +191,7 @@ void MainWindow::filter_view() {
 void MainWindow::refresh_separators() {
     auto set_shown = [](auto c, auto& s) { if (c) s.show(); else s.hide(); };
     auto p = !pinned_boxes.empty();
-    auto f = !fav_boxes.empty() && !is_filtered;
+    auto f = !fav_boxes.empty();
     auto a1 = !filtered_boxes.empty() && is_filtered;
     auto a2 = !apps_boxes.empty() && !is_filtered;
     auto a = a1 || a2;

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -23,6 +23,9 @@ MainWindow::MainWindow(size_t fav_size, size_t pinned_size)
     searchbox
         .signal_search_changed()
         .connect(sigc::mem_fun(*this, &MainWindow::filter_view));
+    searchbox.set_placeholder_text("Type to search");
+    searchbox.set_sensitive(true);
+    searchbox.set_name("searchbox");
     apps_grid.set_column_spacing(5);
     apps_grid.set_row_spacing(5);
     apps_grid.set_column_homogeneous(true);
@@ -107,7 +110,9 @@ bool MainWindow::on_key_press_event(GdkEventKey* key_event) {
                 // its contents become selected
                 // and the incoming character will overwrite them
                 // so we make sure to drop the selection
-                this -> searchbox.prepare_to_insertion();
+                this -> searchbox.select_region(0, 0);
+                this -> searchbox.set_position(-1);
+            
             }
     }
     // Delegate handling to the base class
@@ -234,21 +239,14 @@ void MainWindow::toggle_pinned(GridBox& box) {
     auto is_pinned = box.pinned == GridBox::Pinned;
     box.pinned = GridBox::PinTag{ !is_pinned };
 
-    // init just to use type deduction
     auto* from_grid = &this->apps_grid;
     auto* from = &this->apps_boxes;
 
-    // actual initialization here
-    switch (box.favorite) {
-        case GridBox::Common:
-            from = &this->apps_boxes;
-            from_grid = &this->apps_grid;
-            break;
-        case GridBox::Favorite:
-            from = &this->fav_boxes;
-            from_grid = &this->favs_grid;
-            break;
+    if (box.favorite) {
+        from_grid = &this->favs_grid;
+        from = &this->fav_boxes;
     }
+
     auto* to = &this->pinned_boxes;
     auto* to_grid = &this->pinned_grid;
     if (is_pinned) {
@@ -347,15 +345,4 @@ void GridBox::on_activate() {
     std::system(exec.data());
     auto toplevel = dynamic_cast<MainWindow*>(this->get_toplevel());
     toplevel->close();
-}
-
-GridSearch::GridSearch() {
-    set_placeholder_text("Type to search");
-    set_sensitive(true);
-    set_name("searchbox");
-}
-
-void GridSearch::prepare_to_insertion() {
-    select_region(0, 0);
-    set_position(-1);
 }

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -202,8 +202,6 @@ void MainWindow::build_grids() {
     build_grid(this->favs_grid, this->fav_boxes);
     build_grid(this->apps_grid, this->apps_boxes);
 
-    this -> focus_first_box();
-
     this -> pinned_grid.show_all_children();
     this -> favs_grid.show_all_children();
     this -> apps_grid.show_all_children();
@@ -285,8 +283,17 @@ void MainWindow::toggle_pinned(GridBox& box) {
     fill_hole(x, y, *from_grid, x_, y_);
     from_grid->thaw_child_notify();    
 
-    to->push_back(&box);
-    to_grid->attach(box, xnew, ynew, 1, 1);
+    auto name = box.name.casefold();
+    auto iter = std::find_if(to->begin(), to->end(), [&name](auto e) {
+        return name < e->name.casefold();
+    });
+    to->insert(iter, &box);
+    to_grid->foreach([to_grid](auto& child) {
+        to_grid->remove(child);
+    });
+    build_grid(*to_grid, *to);
+    //to->push_back(&box);
+    //to_grid->attach(box, xnew, ynew, 1, 1);
 }
 
 /*

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -159,19 +159,14 @@ void MainWindow::filter_view() {
 }
 
 void MainWindow::refresh_separators() {
-    auto empty = 0;
-    empty += pinned_boxes.empty();
-    empty += fav_boxes.empty() && favs_grid.get_visible();
-    empty += apps_boxes.empty();
-    if (empty <= 1) {
+    auto set_shown = [](auto c, auto& s) { if (c) s.show(); else s.hide(); };
+    auto p = !pinned_boxes.empty();
+    auto f = !fav_boxes.empty() && favs_grid.get_visible();
+    auto a = !apps_boxes.empty();
+    set_shown(p && f, separator1);
+    set_shown(f && a, separator);
+    if (p && a) {
         separator.show();
-    } else {
-        separator.hide();
-    }
-    if (empty == 0) {
-        separator1.show();
-    } else {
-        separator1.hide();
     }
 }
 

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -38,6 +38,7 @@ MainWindow::MainWindow(size_t fav_size, size_t pinned_size)
         grid.set_row_spacing(5);
         grid.set_homogeneous(true);
         grid.set_halign(Gtk::ALIGN_CENTER);
+        grid.set_selection_mode(Gtk::SELECTION_NONE);
     };
     setup_grid(apps_grid);
     setup_grid(favs_grid);
@@ -181,6 +182,7 @@ void MainWindow::build_grids() {
     auto build_grid = [](auto& grid, auto& container) {
         for (auto child : container) {
             grid.add(*child);
+            child->get_parent()->set_can_focus(false); // FlowBoxChild shouldn't consume focus
         }
         refresh_max_children_per_line(grid, container);
     };

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -140,6 +140,7 @@ inline auto refresh_max_children_per_line = [](auto& flowbox, auto& container) {
     auto size = container.size();
     decltype(size) cols = num_col;
     if (auto min = std::min(cols, size)) {
+        flowbox.set_min_children_per_line(std::min(size, cols));
         flowbox.set_max_children_per_line(std::min(size, cols));
     }
 };

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -72,7 +72,8 @@ MainWindow::MainWindow()
     scrolled_window.add(inner_vbox);
 
     pinned_hbox.pack_start(pinned_grid, Gtk::PACK_EXPAND_WIDGET, 0);
-    inner_vbox.pack_start(pinned_hbox, Gtk::PACK_EXPAND_PADDING, 5);
+    inner_vbox.set_halign(Gtk::ALIGN_CENTER);
+    inner_vbox.pack_start(pinned_hbox, Gtk::PACK_SHRINK, 5);
     inner_vbox.pack_start(separator1, false, true, 0);
     
     favs_hbox.pack_start(favs_grid, true, false, 0);
@@ -80,7 +81,7 @@ MainWindow::MainWindow()
     inner_vbox.pack_start(separator, false, true, 0);
 
     apps_hbox.pack_start(apps_grid, Gtk::PACK_EXPAND_PADDING);
-    inner_vbox.pack_start(apps_hbox, true, true, 0);
+    inner_vbox.pack_start(apps_hbox, Gtk::PACK_SHRINK);
 
     outer_vbox.pack_start(scrolled_window, Gtk::PACK_EXPAND_WIDGET);
     scrolled_window.show_all_children();

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -154,6 +154,14 @@ void MainWindow::filter_view() {
         this -> favs_grid.show();
     }
     this -> apps_grid.invalidate_filter();
+    // TODO: fix this ugly hack
+    // I know no way to get total count of filtered items in FlowBox
+    // so we'll count them on our own
+    decltype(num_col) filtered_count = 0;
+    this -> apps_grid.foreach([&filtered_count](auto& child) {
+        filtered_count += child.get_visible();
+    });
+    this -> apps_grid.set_max_children_per_line(std::min(num_col, filtered_count));
     this -> focus_first_box();
     apps_grid.thaw_child_notify();
 }

--- a/grid/grid_tools.cc
+++ b/grid/grid_tools.cc
@@ -175,7 +175,7 @@ std::optional<DesktopEntry> desktop_entry(std::string&& path, const std::string&
                 std::visit(visitor {
                     [dest, pos, &view](nop_t) { *dest = view.substr(pos); },
                     [dest, pos, &view](cut_t) {
-                        auto idx = view.find_first_of('%', pos);
+                        auto idx = view.find(" %", pos);
                         if (idx == std::string_view::npos) {
                             idx = std::size(view);
                         }

--- a/grid/grid_tools.cc
+++ b/grid/grid_tools.cc
@@ -116,11 +116,9 @@ std::optional<DesktopEntry> desktop_entry(std::string&& path, const std::string&
     std::ifstream file(path);
     std::string str;
 
-    std::string name {};            // Name=
     std::string name_ln {};         // localized: Name[ln]=
     std::string loc_name = "Name[" + lang + "]=";
 
-    std::string comment {};         // Comment=
     std::string comment_ln {};      // localized: Comment[ln]=
     std::string loc_comment = "Comment[" + lang + "]=";
 

--- a/grid/grid_tools.cc
+++ b/grid/grid_tools.cc
@@ -55,42 +55,6 @@ std::string get_pinned_path() {
 }
 
 /*
- * Adds pinned entry and saves pinned cache file
- * */
-void add_and_save_pinned(const std::string& command) {
-    // Add if not yet pinned
-    if (std::find(pinned.begin(), pinned.end(), command) == pinned.end()) {
-        pinned.push_back(command);
-        std::ofstream out_file(pinned_file);
-        for (const auto &e : pinned) out_file << e << "\n";
-    }
-}
-
-/*
- * Removes pinned entry and saves pinned cache file
- * */
-void remove_and_save_pinned(const std::string& command) {
-    // Find the item index
-    bool found = false;
-    std::size_t idx;
-    for (std::size_t i = 0; i < pinned.size(); i++) {
-        if (pinned[i] == command) {
-            found = true;
-            idx = i;
-            break;
-        }
-    }
-
-    if (found) {
-        pinned.erase(pinned.begin() + idx);
-        std::ofstream out_file(pinned_file);
-        for (const auto &e : pinned) {
-            out_file << e << "\n";
-        }
-    }
-}
-
-/*
  * Returns locations of .desktop files
  * */
 std::vector<std::string> get_app_dirs() {


### PR DESCRIPTION
While you were supposedly taking a break, I wanted to implement pin/unpin not closing the application. But you've done the same, so I think it would be wise to provide my implementation.

I've reworked internal structure of grid's MainWindow object. All boxes are stored in one place now, they were given a tags according to which pointers to them are arranged. Working with pointers instead of actual objects allows for simpler and faster manipulations.

Also, I've took my time and rewrote DesktopEntry parser. While not so straightforward, it gives me avg boost of 10-15ms.

This is a draft for there is a number of issues I'd like to address before merging.

- [x] When pinning/unpinning, the grid should remain sorted;
- [x] Number of desktop entries is not shown on startup (the first box receives focus somehow);
- [x] Sometimes, if pinning/unpinning too many items (for me it usually takes pinning all the apps and then unpinning them all back), the logic breaks;
- [x] Double-check if boxes are loading correctly (favourites bug);
- [ ] Provide explanatory comments where needed.

As far as I could test, what I've done fixes favourites. I've reordered the way we load the boxes (pins first, then favourites, then the rest). Because string::empty should return true on moved-from strings, it should be sufficient to avoid this issue. Yet, I'd like to be double-sure.
