### PR TITLE
support for custom background colour

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ To uninstall:
 $ sudo ninja -C builddir uninstall
 ```
 
+**Note: the descriptions below apply to the `master` branch. Certain features may or may not be available in the latest
+release, as well as in the current package for your Linux distribution.**
+
 # nwggrid
 
 This command creates a GNOME-like application grid, with the search box, optionally prepended with a row of `-f` favourites
@@ -78,19 +81,25 @@ This only works with the `-p` argument:
 
 ```
 $ nwggrid -h
-GTK application grid: nwggrid v0.1.8 (c) Piotr Miller 2020
+GTK application grid: nwggrid 0.3.1 (c) Piotr Miller 2020 & Contributors
 
 Options:
--h            show this help message and exit
--f            display favourites (most used entries)
--p            display pinned entries
--o <opacity>  background opacity (0.0 - 1.0, default 0.9)
--n <col>      number of grid columns (default: 6)
--s <size>     button image size (default: 72)
--c <name>     css file name (default: style.css)
--l <ln>       force use of <ln> language
--wm <wmname>  window manager name (if can not be detected)
+-h               show this help message and exit
+-f               display favourites (most used entries)
+-p               display pinned entries
+-o <opacity>     default (black) background opacity (0.0 - 1.0, default 0.9)
+-b <background>  background colour in RRGGBB or RRGGBBAA format (RRGGBBAA alpha overrides <opacity>)
+-n <col>         number of grid columns (default: 6)
+-s <size>        button image size (default: 72)
+-c <name>        css file name (default: style.css)
+-l <ln>          force use of <ln> language
+-wm <wmname>     window manager name (if can not be detected)
 ```
+
+### Custom background
+
+Use -b <RRGGBB> | <RRGGBBAA> argument (w/o #) to define custom background colour. If alpha value given, it overrides
+the opacity, as well default, as defined with the -o <opacity> argument.
 
 ### Custom styling
 
@@ -107,19 +116,25 @@ This command creates a horizontal or vertical button bar, out of a template file
 
 ```
 $ nwgbar -h
-GTK button bar: nwgbar v0.1.8 (c) Piotr Miller 2020
+GTK button bar: nwgbar 0.3.1 (c) Piotr Miller & Contributors 2020
 
 Options:
--h            show this help message and exit
--v            arrange buttons vertically
--ha <l>|<r>   horizontal alignment left/right (default: center)
--va <t>|<b>   vertical alignment top/bottom (default: middle)
--t <name>     template file name (default: bar.json)
--c <name>     css file name (default: style.css)
--o <opacity>  background opacity (0.0 - 1.0, default 0.9)
--s <size>     button image size (default: 72)
--wm <wmname>  window manager name (if can not be detected)
+-h               show this help message and exit
+-v               arrange buttons vertically
+-ha <l>|<r>      horizontal alignment left/right (default: center)
+-va <t>|<b>      vertical alignment top/bottom (default: middle)
+-t <name>        template file name (default: bar.json)
+-c <name>        css file name (default: style.css)
+-o <opacity>     background opacity (0.0 - 1.0, default 0.9)
+-b <background>  background colour in RRGGBB or RRGGBBAA format (RRGGBBAA alpha overrides <opacity>)
+-s <size>        button image size (default: 72)
+-wm <wmname>     window manager name (if can not be detected)
 ```
+
+### Custom background
+
+Use -b <RRGGBB> | <RRGGBBAA> argument (w/o #) to define custom background colour. If alpha value given, it overrides
+the opacity, as well default, as defined with the -o <opacity> argument.
 
 ### Customization
 
@@ -173,22 +188,27 @@ This program provides 2 commands:
 ### Usage
 
 ```
-$ $ nwgdmenu -h
-GTK dynamic menu: nwgdmenu 0.1.9 (c) Piotr Miller & Contributors 2020
+$ nwgdmenu -h
+GTK dynamic menu: nwgdmenu 0.3.1 (c) Piotr Miller & Contributors 2020
 
-<input> | nwgdmenu - displays newline-separated stdin input as a GTK menu(1)
+<input> | nwgdmenu - displays newline-separated stdin input as a GTK menu
 nwgdmenu - creates a GTK menu out of commands found in $PATH
 
 Options:
--h            show this help message and exit
--n            no search box
--ha <l>|<r>   horizontal alignment left/right (default: center)
--va <t>|<b>   vertical alignment top/bottom (default: middle)
--r <rows>     number of rows (default: 20)
--c <name>     css file name (default: style.css)
--o <opacity>  background opacity (0.0 - 1.0, default 0.3)
--wm <wmname>  window manager name (if can not be detected)
--run          ignore stdin, always build from commands in $PATH(1)
+-h               show this help message and exit
+-n               no search box
+-ha <l>|<r>      horizontal alignment left/right (default: center)
+-va <t>|<b>      vertical alignment top/bottom (default: middle)
+-r <rows>        number of rows (default: 20)
+-c <name>        css file name (default: style.css)
+-o <opacity>     background opacity (0.0 - 1.0, default 0.3)
+-b <background>  background colour in RRGGBB or RRGGBBAA format (RRGGBBAA alpha overrides <opacity>)
+-wm <wmname>     window manager name (if can not be detected)
+-run             ignore stdin, always build from commands in $PATH(1)
+
+Hotkeys:
+Delete        clear search box
+Insert        switch case sensitivity
 ```
 
 (1) _The program should auto-detect if something has been passed in `stdin`, and build the menu out of the `stdin` content
@@ -201,6 +221,11 @@ Notice: if you start your WM from a script (w/o DM), only sway and i3 will be au
 `nwgdmenu -wm dwm`
 
 The generic name `tiling` will be accepted as well.
+
+### Custom background
+
+Use -b <RRGGBB> | <RRGGBBAA> argument (w/o #) to define custom background colour. If alpha value given, it overrides
+the opacity, as well default, as defined with the -o <opacity> argument.
 
 ### Custom styling
 

--- a/bar/bar.cc
+++ b/bar/bar.cc
@@ -22,15 +22,16 @@ std::string wm {""};            // detected or forced window manager name
 const char* const HELP_MESSAGE =
 "GTK button bar: nwgbar " VERSION_STR " (c) Piotr Miller & Contributors 2020\n\n\
 Options:\n\
--h            show this help message and exit\n\
--v            arrange buttons vertically\n\
--ha <l>|<r>   horizontal alignment left/right (default: center)\n\
--va <t>|<b>   vertical alignment top/bottom (default: middle)\n\
--t <name>     template file name (default: bar.json)\n\
--c <name>     css file name (default: style.css)\n\
--o <opacity>  background opacity (0.0 - 1.0, default 0.9)\n\
--s <size>     button image size (default: 72)\n\
--wm <wmname>  window manager name (if can not be detected)\n";
+-h               show this help message and exit\n\
+-v               arrange buttons vertically\n\
+-ha <l>|<r>      horizontal alignment left/right (default: center)\n\
+-va <t>|<b>      vertical alignment top/bottom (default: middle)\n\
+-t <name>        template file name (default: bar.json)\n\
+-c <name>        css file name (default: style.css)\n\
+-o <opacity>     background opacity (0.0 - 1.0, default 0.9)\n\
+-b <background>  background colour in RRGGBB or RRGGBBAA format (RRGGBBAA alpha overrides <opacity>)\n\
+-s <size>        button image size (default: 72)\n\
+-wm <wmname>     window manager name (if can not be detected)\n";
 
 int main(int argc, char *argv[]) {
     std::string definition_file {"bar.json"};
@@ -120,6 +121,11 @@ int main(int argc, char *argv[]) {
         } catch (...) {
             std::cerr << "\nERROR: Invalid opacity value\n\n";
         }
+    }
+
+    std::string_view bcg = input.getCmdOption("-b");
+    if (!bcg.empty()) {
+        set_background(bcg);
     }
 
     auto i_size = input.getCmdOption("-s");

--- a/bar/bar.cc
+++ b/bar/bar.cc
@@ -17,9 +17,9 @@
 #include "bar.h"
 
 int image_size {72};            // button image size in pixels
-double opacity {0.9};           // overlay window opacity
+RGBA background = {0.0, 0.0, 0.0, 0.9};
 std::string wm {""};            // detected or forced window manager name
-const char* const HELP_MESSAGE = 
+const char* const HELP_MESSAGE =
 "GTK button bar: nwgbar " VERSION_STR " (c) Piotr Miller & Contributors 2020\n\n\
 Options:\n\
 -h            show this help message and exit\n\
@@ -45,9 +45,9 @@ int main(int argc, char *argv[]) {
 
     pid_t pid = getpid();
     std::string mypid = std::to_string(pid);
-    
+
     std::string pid_file = "/var/run/user/" + std::to_string(getuid()) + "/nwgbar.pid";
-    
+
     int saved_pid {};
     if (std::ifstream(pid_file)) {
         try {
@@ -102,7 +102,7 @@ int main(int argc, char *argv[]) {
     if (!css_name.empty()){
         custom_css_file = css_name;
     }
-    
+
     auto wm_name = input.getCmdOption("-wm");
     if (!wm_name.empty()){
         wm = wm_name;
@@ -113,7 +113,7 @@ int main(int argc, char *argv[]) {
         try {
             auto o = std::stod(std::string{opa});
             if (o >= 0.0 && o <= 1.0) {
-                opacity = o;
+                background.alpha = o;
             } else {
                 std::cerr << "\nERROR: Opacity must be in range 0.0 to 1.0\n\n";
             }
@@ -188,7 +188,7 @@ int main(int argc, char *argv[]) {
     if (wm.empty()) {
         wm = detect_wm();
     }
-    
+
     std::cout << "WM: " << wm << "\n";
 
     /* turn off borders, enable floating on sway */

--- a/bar/bar.h
+++ b/bar/bar.h
@@ -26,7 +26,6 @@
 namespace fs = std::filesystem;
 namespace ns = nlohmann;
 
-extern double opacity;
 extern std::string wm;
 
 class BarBox : public AppBox {

--- a/common/nwg_classes.cc
+++ b/common/nwg_classes.cc
@@ -47,9 +47,9 @@ CommonWindow::~CommonWindow() { }
 bool CommonWindow::on_draw(const Cairo::RefPtr<Cairo::Context>& cr) {
     cr->save();
     if (_SUPPORTS_ALPHA) {
-        cr->set_source_rgba(0.0, 0.0, 0.0, opacity);
+        cr->set_source_rgba(background.red, background.green, background.blue, background.alpha);
     } else {
-        cr->set_source_rgb(0.0, 0.0, 0.0);
+        cr->set_source_rgb(background.red, background.green, background.blue);
     }
     cr->set_operator(Cairo::OPERATOR_SOURCE);
     cr->paint();

--- a/common/nwg_classes.cc
+++ b/common/nwg_classes.cc
@@ -2,6 +2,8 @@
  * Classes for nwg-launchers
  * Copyright (c) 2020 Érico Nogueira
  * e-mail: ericonr@disroot.org
+ * Copyright (c) 2020 Piotr Miller
+ * e-mail: nwg.piotr@gmail.com
  * Website: http://nwg.pl
  * Project: https://github.com/nwg-piotr/nwg-launchers
  * License: GPL3

--- a/common/nwg_classes.h
+++ b/common/nwg_classes.h
@@ -31,7 +31,6 @@ class InputParser{
         std::vector <std::string_view> tokens;
 };
 
-extern double opacity;
 class CommonWindow : public Gtk::Window {
     public:
         CommonWindow(const Glib::ustring&, const Glib::ustring&);
@@ -78,3 +77,11 @@ struct DesktopEntry {
     std::string comment;
     bool no_display {false};
 };
+
+struct RGBA {
+    double red;
+    double green;
+    double blue;
+    double alpha;
+};
+extern RGBA background;

--- a/common/nwg_classes.h
+++ b/common/nwg_classes.h
@@ -2,6 +2,8 @@
  * Classes for nwg-launchers
  * Copyright (c) 2020 Érico Nogueira
  * e-mail: ericonr@disroot.org
+ * Copyright (c) 2020 Piotr Miller
+ * e-mail: nwg.piotr@gmail.com
  * Website: http://nwg.pl
  * Project: https://github.com/nwg-piotr/nwg-launchers
  * License: GPL3

--- a/common/nwg_tools.cc
+++ b/common/nwg_tools.cc
@@ -2,6 +2,8 @@
  * Tools for nwg-launchers
  * Copyright (c) 2020 Érico Nogueira
  * e-mail: ericonr@disroot.org
+ * Copyright (c) 2020 Piotr Miller
+ * e-mail: nwg.piotr@gmail.com
  * Website: http://nwg.pl
  * Project: https://github.com/nwg-piotr/nwg-launchers
  * License: GPL3

--- a/common/nwg_tools.cc
+++ b/common/nwg_tools.cc
@@ -125,7 +125,7 @@ Geometry display_geometry(const std::string& wm, Glib::RefPtr<Gdk::Display> disp
  * */
 Gtk::Image* app_image(const Gtk::IconTheme& icon_theme, const std::string& icon) {
     Glib::RefPtr<Gdk::Pixbuf> pixbuf;
-    
+
     try {
         if (icon.find_first_of("/") == std::string::npos) {
             pixbuf = icon_theme.load_icon(icon, image_size, Gtk::ICON_LOOKUP_FORCE_SIZE);
@@ -205,7 +205,7 @@ std::string_view take_last_by(std::string_view str, std::string_view delimiter) 
     if (pos != std::string_view::npos) {
         return str.substr(pos + 1);
     }
-    return str;   
+    return str;
 }
 
 /*
@@ -224,6 +224,13 @@ ns::json string_to_json(const std::string& jsonString) {
 void save_json(const ns::json& json_obj, const std::string& filename) {
     std::ofstream o(filename);
     o << std::setw(2) << json_obj << std::endl;
+}
+
+/*
+ * Sets RGBA background according to hex strings
+* */
+void set_background(const std::string_view s) {
+    std::cout << s << " | " << background.alpha << "\n";
 }
 
 /*

--- a/common/nwg_tools.cc
+++ b/common/nwg_tools.cc
@@ -255,7 +255,6 @@ void set_background(const std::string_view string) {
         } else {
             std::cerr << "ERROR: invalid color value. Should be RRGGBB or RRGGBBAA";
         }
-        std::cout << "R: " << background.red << " G: " << background.green << " B: " << background.blue << " A: " << background.alpha << "\n";
     }
     catch (...) {
         std::cerr << "Error parsing RGB(A) value \n";

--- a/common/nwg_tools.cc
+++ b/common/nwg_tools.cc
@@ -229,8 +229,34 @@ void save_json(const ns::json& json_obj, const std::string& filename) {
 /*
  * Sets RGBA background according to hex strings
 * */
-void set_background(const std::string_view s) {
-    std::cout << s << " | " << background.alpha << "\n";
+void set_background(const std::string_view string) {
+    std::string hex_string {"0x"};
+    unsigned long int rgba;
+    std::stringstream ss;
+    try {
+        if (string.find("#") == 0) {
+            hex_string += string.substr(1);
+        } else {
+            hex_string += string;
+        }
+        ss << std::hex << hex_string;
+        ss >> rgba;
+        if (hex_string.size() == 8) {
+            background.red = ((rgba >> 16) & 0xff) / 255.0;;
+            background.green = ((rgba >> 8) & 0xff) / 255.0;;
+            background.blue = (rgba & 0xff) / 255.0;
+        } else if (hex_string.size() == 10) {
+            background.red = ((rgba >> 32) & 0xff) / 255.0;
+            background.green = ((rgba >> 16) & 0xff) / 255.0;
+            background.blue = ((rgba >> 8) & 0xff) / 255.0;
+            background.alpha = (rgba & 0xff) / 255.0;
+        } else {
+            std::cerr << "ERROR: invalid color value. Should be RRGGBB or RRGGBBAA";
+        }
+    }
+    catch (...) {
+        std::cerr << "Error parsing RGB(A) value \n";
+    }
 }
 
 /*

--- a/common/nwg_tools.cc
+++ b/common/nwg_tools.cc
@@ -242,17 +242,18 @@ void set_background(const std::string_view string) {
         ss << std::hex << hex_string;
         ss >> rgba;
         if (hex_string.size() == 8) {
-            background.red = ((rgba >> 16) & 0xff) / 255.0;;
-            background.green = ((rgba >> 8) & 0xff) / 255.0;;
-            background.blue = (rgba & 0xff) / 255.0;
+            background.red = ((rgba >> 16) & 0xff) / 255.0;
+            background.green = ((rgba >> 8) & 0xff) / 255.0;
+            background.blue = ((rgba) & 0xff) / 255.0;
         } else if (hex_string.size() == 10) {
-            background.red = ((rgba >> 32) & 0xff) / 255.0;
+            background.red = ((rgba >> 24) & 0xff) / 255.0;
             background.green = ((rgba >> 16) & 0xff) / 255.0;
             background.blue = ((rgba >> 8) & 0xff) / 255.0;
-            background.alpha = (rgba & 0xff) / 255.0;
+            background.alpha = ((rgba) & 0xff) / 255.0;
         } else {
             std::cerr << "ERROR: invalid color value. Should be RRGGBB or RRGGBBAA";
         }
+        std::cout << "R: " << background.red << " G: " << background.green << " B: " << background.blue << " A: " << background.alpha << "\n";
     }
     catch (...) {
         std::cerr << "Error parsing RGB(A) value \n";

--- a/common/nwg_tools.h
+++ b/common/nwg_tools.h
@@ -2,6 +2,8 @@
  * Tools for nwg-launchers
  * Copyright (c) 2020 Érico Nogueira
  * e-mail: ericonr@disroot.org
+ * Copyright (c) 2020 Piotr Miller
+ * e-mail: nwg.piotr@gmail.com
  * Website: http://nwg.pl
  * Project: https://github.com/nwg-piotr/nwg-launchers
  * License: GPL3

--- a/common/nwg_tools.h
+++ b/common/nwg_tools.h
@@ -36,6 +36,7 @@ std::string_view take_last_by(std::string_view, std::string_view);
 
 ns::json string_to_json(const std::string&);
 void save_json(const ns::json&, const std::string&);
+void set_background(const std::string_view);
 
 std::string get_output(const std::string&);
 

--- a/dmenu/dmenu.cc
+++ b/dmenu/dmenu.cc
@@ -42,15 +42,16 @@ const char* const HELP_MESSAGE =
 <input> | nwgdmenu - displays newline-separated stdin input as a GTK menu\n\
 nwgdmenu - creates a GTK menu out of commands found in $PATH\n\n\
 Options:\n\
--h            show this help message and exit\n\
--n            no search box\n\
--ha <l>|<r>   horizontal alignment left/right (default: center)\n\
--va <t>|<b>   vertical alignment top/bottom (default: middle)\n\
--r <rows>     number of rows (default: " STR(ROWS_DEFAULT) ")\n\
--c <name>     css file name (default: style.css)\n\
--o <opacity>  background opacity (0.0 - 1.0, default 0.3)\n\
--wm <wmname>  window manager name (if can not be detected)\n\
--run          ignore stdin, always build from commands in $PATH\n\n\
+-h               show this help message and exit\n\
+-n               no search box\n\
+-ha <l>|<r>      horizontal alignment left/right (default: center)\n\
+-va <t>|<b>      vertical alignment top/bottom (default: middle)\n\
+-r <rows>        number of rows (default: " STR(ROWS_DEFAULT) ")\n\
+-c <name>        css file name (default: style.css)\n\
+-o <opacity>     background opacity (0.0 - 1.0, default 0.3)\n\
+-b <background>  background colour in RRGGBB or RRGGBBAA format (RRGGBBAA alpha overrides <opacity>)\n\
+-wm <wmname>     window manager name (if can not be detected)\n\
+-run             ignore stdin, always build from commands in $PATH\n\n\
 Hotkeys:\n\
 Delete        clear search box\n\
 Insert        switch case sensitivity\n";
@@ -147,6 +148,11 @@ int main(int argc, char *argv[]) {
         } catch (...) {
             std::cerr << "\nERROR: Invalid opacity value\n\n";
         }
+    }
+
+    std::string_view bcg = input.getCmdOption("-b");
+    if (!bcg.empty()) {
+        set_background(bcg);
     }
 
     auto rw = input.getCmdOption("-r");

--- a/dmenu/dmenu.cc
+++ b/dmenu/dmenu.cc
@@ -26,7 +26,7 @@ int image_size {72};                        // make linker happy
 
 std::string h_align {""};                   // horizontal alignment
 std::string v_align {""};                   // vertical alignment
-double opacity (0.3);                       // overlay window opacity
+RGBA background = {0.0, 0.0, 0.0, 0.3};
 std::string wm {""};                        // detected or forced window manager name
 std::string settings_file {""};
 
@@ -140,7 +140,7 @@ int main(int argc, char *argv[]) {
         try {
             auto o = std::stod(std::string{opa});
             if (o >= 0.0 && o <= 1.0) {
-                opacity = o;
+                background.alpha = o;
             } else {
                 std::cerr << "\nERROR: Opacity must be in range 0.0 to 1.0\n\n";
             }
@@ -205,7 +205,7 @@ int main(int argc, char *argv[]) {
         }
 
         /* Sort case insensitive */
-        std::sort(all_commands.begin(), all_commands.end(), [](auto& a, auto& b) { 
+        std::sort(all_commands.begin(), all_commands.end(), [](auto& a, auto& b) {
             return std::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end(), [](auto a, auto b) {
                 return std::tolower(a) < std::tolower(b);
             });

--- a/dmenu/dmenu.h
+++ b/dmenu/dmenu.h
@@ -30,7 +30,6 @@ namespace ns = nlohmann;
 
 extern std::string h_align;
 extern std::string v_align;
-extern double opacity;
 extern std::string wm;
 extern std::string settings_file;
 

--- a/grid/grid.cc
+++ b/grid/grid.cc
@@ -38,7 +38,7 @@ Options:\n\
 -f               display favourites (most used entries)\n\
 -p               display pinned entries \n\
 -o <opacity>     default (black) background opacity (0.0 - 1.0, default 0.9)\n\
--b <background>  background colour in #RRGGBB or #RRGGBBAA format (#RRGGBBAA overrides <opacity>)\n\
+-b <background>  background colour in RRGGBB or RRGGBBAA format (RRGGBBAA alpha overrides <opacity>)\n\
 -n <col>         number of grid columns (default: 6)\n\
 -s <size>        button image size (default: 72)\n\
 -c <name>        css file name (default: style.css)\n\

--- a/grid/grid.cc
+++ b/grid/grid.cc
@@ -18,7 +18,7 @@
 #include "grid.h"
 
 bool pins = false;              // whether to display pinned
-double opacity = 0.9;           // overlay window opacity
+RGBA background = {0.0, 0.0, 0.0, 0.9};
 std::string wm {""};            // detected or forced window manager name
 
 int num_col = 6;                // number of grid columns
@@ -34,15 +34,16 @@ const char* const HELP_MESSAGE =
 "GTK application grid: nwggrid " VERSION_STR " (c) Piotr Miller 2020 & Contributors \n\n\
 \
 Options:\n\
--h            show this help message and exit\n\
--f            display favourites (most used entries)\n\
--p            display pinned entries \n\
--o <opacity>  background opacity (0.0 - 1.0, default 0.9)\n\
--n <col>      number of grid columns (default: 6)\n\
--s <size>     button image size (default: 72)\n\
--c <name>     css file name (default: style.css)\n\
--l <ln>       force use of <ln> language\n\
--wm <wmname>  window manager name (if can not be detected)\n";
+-h               show this help message and exit\n\
+-f               display favourites (most used entries)\n\
+-p               display pinned entries \n\
+-o <opacity>     default (black) background opacity (0.0 - 1.0, default 0.9)\n\
+-b <background>  background colour in #RRGGBB or #RRGGBBAA format (#RRGGBBAA overrides <opacity>)\n\
+-n <col>         number of grid columns (default: 6)\n\
+-s <size>        button image size (default: 72)\n\
+-c <name>        css file name (default: style.css)\n\
+-l <ln>          force use of <ln> language\n\
+-wm <wmname>     window manager name (if can not be detected)\n";
 
 int main(int argc, char *argv[]) {
     bool favs (false);              // whether to display favourites
@@ -119,13 +120,18 @@ int main(int argc, char *argv[]) {
         try {
             auto o = std::stod(std::string{opa});
             if (o >= 0.0 && o <= 1.0) {
-                opacity = o;
+                background.alpha = o;
             } else {
                 std::cerr << "\nERROR: Opacity must be in range 0.0 to 1.0\n\n";
             }
         } catch(...) {
             std::cerr << "\nERROR: Invalid opacity value\n\n";
         }
+    }
+
+    std::string_view bcg = input.getCmdOption("-b");
+    if (!bcg.empty()) {
+        set_background(bcg);
     }
 
     auto i_size = input.getCmdOption("-s");

--- a/grid/grid.h
+++ b/grid/grid.h
@@ -27,7 +27,6 @@ namespace fs = std::filesystem;
 namespace ns = nlohmann;
 
 extern bool pins;
-extern double opacity;
 extern std::string wm;
 
 extern int num_col;

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project('nwg-launchers', 'cpp',
 			'warning_level=3'
 			],
 	license: 'GPL-3.0-or-later',
-	version: '0.3.1'
+	version: '0.3.2'
 )
 
 compiler = meson.get_compiler('cpp')


### PR DESCRIPTION
Use `-b <RRGGBB> | <RRGGBBAA>` argument (w/o `#`) to define custom background colour. If alpha value given, it overrides the opacity, as well default, as defined with the `-o <opacity>` argument. Works in all 3 launchers. Resolves #85 