### PR TITLE
Dealing with PID file in a better way

### DIFF
--- a/bar/bar.cc
+++ b/bar/bar.cc
@@ -44,25 +44,7 @@ int main(int argc, char *argv[]) {
     gettimeofday(&tp, NULL);
     long int start_ms = tp.tv_sec * 1000 + tp.tv_usec / 1000;
 
-    pid_t pid = getpid();
-    std::string mypid = std::to_string(pid);
-
-    std::string pid_file = "/var/run/user/" + std::to_string(getuid()) + "/nwgbar.pid";
-
-    int saved_pid {};
-    if (std::ifstream(pid_file)) {
-        try {
-            saved_pid = std::stoi(read_file_to_string(pid_file));
-            if (kill(saved_pid, 0) != -1) {  // found running instance!
-                kill(saved_pid, 9);
-                save_string_to_file(mypid, pid_file);
-                std::exit(0);
-            }
-        } catch (...) {
-            std::cerr << "\nError reading pid file\n\n";
-        }
-    }
-    save_string_to_file(mypid, pid_file);
+    create_pid_file_or_kill_pid("nwgbar");
 
     std::string lang ("");
 

--- a/common/nwg_tools.h
+++ b/common/nwg_tools.h
@@ -21,7 +21,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include <nwg_classes.h>
+#include "nwg_classes.h"
 
 namespace ns = nlohmann;
 
@@ -45,3 +45,5 @@ std::string get_output(const std::string&);
 extern int image_size;
 Gtk::Image* app_image(const Gtk::IconTheme& theme, const std::string& icon);
 Geometry display_geometry(const std::string&, Glib::RefPtr<Gdk::Display>, Glib::RefPtr<Gdk::Window>);
+
+void create_pid_file_or_kill_pid(std::string);

--- a/dmenu/dmenu.cc
+++ b/dmenu/dmenu.cc
@@ -8,7 +8,6 @@
  * */
 
 #include <sys/time.h>
-#include <unistd.h>
 
 #include <charconv>
 
@@ -67,25 +66,7 @@ int main(int argc, char *argv[]) {
         case_sensitive = false;
     }
 
-    pid_t pid = getpid();
-    std::string mypid = std::to_string(pid);
-
-    std::string pid_file = "/var/run/user/" + std::to_string(getuid()) + "/nwgdmenu.pid";
-
-    int saved_pid {};
-    if (std::ifstream(pid_file)) {
-        try {
-            saved_pid = std::stoi(read_file_to_string(pid_file));
-            if (kill(saved_pid, 0) != -1) {  // found running instance!
-                kill(saved_pid, 9);
-                save_string_to_file(mypid, pid_file);
-                std::exit(0);
-            }
-        } catch (...) {
-            std::cerr << "\nError reading pid file\n\n";
-        }
-    }
-    save_string_to_file(mypid, pid_file);
+    create_pid_file_or_kill_pid("nwgdmenu");
 
     InputParser input(argc, argv);
     if (input.cmdOptionExists("-h")){

--- a/grid/grid.cc
+++ b/grid/grid.cc
@@ -53,25 +53,7 @@ int main(int argc, char *argv[]) {
     gettimeofday(&tp, NULL);
     long int start_ms = tp.tv_sec * 1000 + tp.tv_usec / 1000;
 
-    pid_t pid = getpid();
-    std::string mypid = std::to_string(pid);
-
-    std::string pid_file = "/var/run/user/" + std::to_string(getuid()) + "/nwggrid.pid";
-
-    int saved_pid {};
-    if (std::ifstream(pid_file)) {
-        try {
-            saved_pid = std::stoi(read_file_to_string(pid_file));
-            if (kill(saved_pid, 0) != -1) {  // found running instance!
-                kill(saved_pid, 9);
-                save_string_to_file(mypid, pid_file);
-                std::exit(0);
-            }
-        } catch (...) {
-            std::cerr << "\nError reading pid file\n\n";
-        }
-    }
-    save_string_to_file(mypid, pid_file);
+    create_pid_file_or_kill_pid("nwggrid");
 
     std::string lang ("");
 


### PR DESCRIPTION
Fixes #96 

I'm not totally happy with how the `runtime_dir` is determined... If we are running only on wayland, `XDG_RUNTIME_DIR` needs to be set, so there isn't much you need to do, but if someone is using X _and_ `XDG_RUNTIME_DIR` isn't set, chances are their system won't even have  `/var/run/$UID` as a folder.