### PR TITLE
nwg_tools: tidy up header.

### DIFF
--- a/bar/bar.cc
+++ b/bar/bar.cc
@@ -16,7 +16,6 @@
 #include "on_event.h"
 #include "bar.h"
 
-int image_size {72};            // button image size in pixels
 RGBA background = {0.0, 0.0, 0.0, 0.9};
 std::string wm {""};            // detected or forced window manager name
 const char* const HELP_MESSAGE =

--- a/common/nwg_tools.cc
+++ b/common/nwg_tools.cc
@@ -15,7 +15,10 @@
 #include <fstream>
 
 #include "nwgconfig.h"
-#include <nwg_tools.h>
+#include "nwg_tools.h"
+
+// extern variables from nwg_tools.h
+int image_size = 72;
 
 /*
  * Returns config dir

--- a/common/nwg_tools.h
+++ b/common/nwg_tools.h
@@ -25,6 +25,8 @@
 
 namespace ns = nlohmann;
 
+extern int image_size; // button image size in pixels
+
 std::string get_config_dir(std::string);
 
 std::string detect_wm(void);
@@ -42,6 +44,5 @@ void set_background(const std::string_view);
 
 std::string get_output(const std::string&);
 
-extern int image_size;
-Gtk::Image* app_image(const Gtk::IconTheme& theme, const std::string& icon);
+Gtk::Image* app_image(const Gtk::IconTheme&, const std::string&);
 Geometry display_geometry(const std::string&, Glib::RefPtr<Gdk::Display>, Glib::RefPtr<Gdk::Window>);

--- a/dmenu/dmenu.cc
+++ b/dmenu/dmenu.cc
@@ -22,8 +22,6 @@
 #define STR_EXPAND(x) #x
 #define STR(x) STR_EXPAND(x)
 
-int image_size {72};                        // make linker happy
-
 std::string h_align {""};                   // horizontal alignment
 std::string v_align {""};                   // vertical alignment
 RGBA background = {0.0, 0.0, 0.0, 0.3};

--- a/grid/grid.cc
+++ b/grid/grid.cc
@@ -22,7 +22,6 @@ RGBA background = {0.0, 0.0, 0.0, 0.9};
 std::string wm {""};            // detected or forced window manager name
 
 int num_col = 6;                // number of grid columns
-int image_size = 72;            // button image size in pixels
 Gtk::Label *description;
 
 std::string pinned_file {};


### PR DESCRIPTION
Move image_size declaration to nwg_tools.c, remove parameter names from
functions in nwg_tools.h.

---

This or #97 will need to be rebased.