### PR TITLE
Add TravisCI for Clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: cpp
+
+os:
+  - freebsd # clang/libc++
+
+before_install:
+  - sudo pkg install -y meson pkgconf gtkmm30 nlohmann-json
+
+script:
+  - meson _build
+  - meson compile -C _build


### PR DESCRIPTION
Avoid #109 in future due to GCC vs. Clang. C++ as used by this project also adds libstdc++ (default on most Linux distros) vs. libc++ (default on Android, macOS, BSDs) into the mix.

`v0.3.2` build log: https://travis-ci.com/github/jbeich/nwg-launchers/builds/184069666