### PR TITLE
Fix `NoDisplay`, at last

### DIFF
--- a/bar/bar.cc
+++ b/bar/bar.cc
@@ -200,6 +200,7 @@ int main(int argc, char *argv[]) {
         return EXIT_FAILURE;
     }
     auto& icon_theme_ref = *icon_theme.get();
+    auto icon_missing = Gdk::Pixbuf::create_from_file(DATA_DIR_STR "/nwgbar/icon-missing.svg");
 
     if (std::filesystem::is_regular_file(css_file)) {
         provider->load_from_path(css_file);
@@ -234,7 +235,7 @@ int main(int argc, char *argv[]) {
 
     /* Create buttons */
     for (auto& entry : bar_entries) {
-        Gtk::Image* image = app_image(icon_theme_ref, entry.icon);
+        Gtk::Image* image = app_image(icon_theme_ref, entry.icon, icon_missing);
         auto& ab = window.boxes.emplace_back(std::move(entry.name),
                                              std::move(entry.exec),
                                              std::move(entry.icon));

--- a/common/nwg_tools.cc
+++ b/common/nwg_tools.cc
@@ -151,7 +151,11 @@ Geometry display_geometry(const std::string& wm, Glib::RefPtr<Gdk::Display> disp
 /*
  * Returns Gtk::Image out of the icon name of file path
  * */
-Gtk::Image* app_image(const Gtk::IconTheme& icon_theme, const std::string& icon) {
+Gtk::Image* app_image(
+    const Gtk::IconTheme& icon_theme,
+    const std::string& icon,
+    const Glib::RefPtr<Gdk::Pixbuf>& fallback
+) {
     Glib::RefPtr<Gdk::Pixbuf> pixbuf;
 
     try {
@@ -164,7 +168,7 @@ Gtk::Image* app_image(const Gtk::IconTheme& icon_theme, const std::string& icon)
         try {
             pixbuf = Gdk::Pixbuf::create_from_file("/usr/share/pixmaps/" + icon, image_size, image_size, true);
         } catch (...) {
-            pixbuf = Gdk::Pixbuf::create_from_file(DATA_DIR_STR "/nwgbar/icon-missing.svg", image_size, image_size, true);
+            pixbuf = fallback;
         }
     }
     auto image = Gtk::manage(new Gtk::Image(pixbuf));

--- a/common/nwg_tools.h
+++ b/common/nwg_tools.h
@@ -44,7 +44,7 @@ void set_background(const std::string_view);
 
 std::string get_output(const std::string&);
 
-Gtk::Image* app_image(const Gtk::IconTheme&, const std::string&);
+Gtk::Image* app_image(const Gtk::IconTheme&, const std::string&, const Glib::RefPtr<Gdk::Pixbuf>&);
 Geometry display_geometry(const std::string&, Glib::RefPtr<Gdk::Display>, Glib::RefPtr<Gdk::Window>);
 
 void create_pid_file_or_kill_pid(std::string);

--- a/grid/grid.cc
+++ b/grid/grid.cc
@@ -227,16 +227,19 @@ int main(int argc, char *argv[]) {
                     at->second = execs.size(); // set index
                     execs.emplace_back(entry->exec);
                     desktop_entries.emplace_back(std::move(*entry));
-                    stats.emplace_back(0, Stats::Common, Stats::Unpinned);
+                    stats.emplace_back(0, 0, Stats::Common, Stats::Unpinned);
                     images.emplace_back(nullptr);
                 }
             }
         }
     }
 
+    int pin_index = 0; // preserve pins order
     for (auto& pin : pinned) {
         if (auto result = desktop_ids.find(pin); result != desktop_ids.end() && result->second) {
             stats[*result->second].pinned = Stats::Pinned;
+            stats[*result->second].position = pin_index;
+            pin_index++;
         }
     }
     for (auto& [fav, clicks] : favourites) {

--- a/grid/grid.cc
+++ b/grid/grid.cc
@@ -196,10 +196,6 @@ int main(int argc, char *argv[]) {
     /* get all applications dirs */
     auto dirs = get_app_dirs();
 
-//    /* get a list of paths to all *.desktop entries */
-//    auto entries = list_entries(app_dirs);
-//    std::cout << entries.size() << " .desktop entries found, ";
-
     gettimeofday(&tp, NULL);
     long int commons_ms  = tp.tv_sec * 1000 + tp.tv_usec / 1000;
 

--- a/grid/grid.cc
+++ b/grid/grid.cc
@@ -59,12 +59,8 @@ int main(int argc, char *argv[]) {
         std::cout << HELP_MESSAGE;
         std::exit(0);
     }
-    if (input.cmdOptionExists("-f")){
-        favs = true;
-    }
-    if (input.cmdOptionExists("-p")){
-        pins = true;
-    }
+    favs = input.cmdOptionExists("-f");
+    pins = input.cmdOptionExists("-p");
     auto forced_lang = input.getCmdOption("-l");
     if (!forced_lang.empty()){
         lang = forced_lang;
@@ -278,7 +274,6 @@ int main(int argc, char *argv[]) {
     }
 
     MainWindow window(execs, stats);
-
     window.show();
 
     /* Detect focused display geometry: {x, y, width, height} */
@@ -295,7 +290,7 @@ int main(int argc, char *argv[]) {
     if (wm == "sway") { // TODO: Use sway-ipc
         auto* cmd = "swaymsg for_window [title=\"~nwggrid*\"] floating enable";
         std::system(cmd);
-        cmd = "swaymsg for_window [title=\"~nwggrid*\"] floating enable";
+        cmd = "swaymsg for_window [title=\"~nwggrid*\"] border none";
         std::system(cmd);
     }
 

--- a/grid/grid.cc
+++ b/grid/grid.cc
@@ -18,6 +18,7 @@
 #include "grid.h"
 
 bool pins = false;              // whether to display pinned
+bool favs = false;              // whether to display favorites
 RGBA background = {0.0, 0.0, 0.0, 0.9};
 std::string wm {""};            // detected or forced window manager name
 
@@ -44,7 +45,6 @@ Options:\n\
 -wm <wmname>     window manager name (if can not be detected)\n";
 
 int main(int argc, char *argv[]) {
-    bool favs (false);              // whether to display favourites
     std::string custom_css_file {"style.css"};
 
     struct timeval tp;
@@ -153,7 +153,6 @@ int main(int argc, char *argv[]) {
             std::cout << cache.size() << " cache entries loaded\n";
         } else {
             std::cout << "No cached favourites found\n";
-            favs = false;   // ignore -f argument from now on
         }
     }
 
@@ -310,6 +309,8 @@ int main(int argc, char *argv[]) {
         }
     }
 
+    window.set_table(&desktop_entries, &stats);
+
     gettimeofday(&tp, NULL);
     long int boxes_ms = tp.tv_sec * 1000 + tp.tv_usec / 1000;
 
@@ -318,9 +319,9 @@ int main(int argc, char *argv[]) {
         if (entry_) {
             auto& entry = *entry_;
             auto& ab = window.emplace_box(std::move(entry.name),
-                                          std::move(entry.exec),
                                           std::move(entry.comment),
-                                          stats[pos]);
+                                          desktop_id,
+                                          pos);
             ab.set_image_position(Gtk::POS_TOP);
             ab.set_image(*images[pos]);
         }
@@ -344,7 +345,5 @@ int main(int argc, char *argv[]) {
     format("\tbs:      ", bs_ms, images_ms);
     format("\tcommons: ", commons_ms, bs_ms);
 
-    app->run(window);
-
-    return 0;
+    return app->run(window);
 }

--- a/grid/grid.cc
+++ b/grid/grid.cc
@@ -264,7 +264,7 @@ int main(int argc, char *argv[]) {
         std::cerr << "ERROR: Failed to load icon theme\n";
     }
     auto& icon_theme_ref = *icon_theme.get();
-    icon_theme_ref.add_resource_path(DATA_DIR_STR "/icon-missing.svg");
+    auto icon_missing = Gdk::Pixbuf::create_from_file(DATA_DIR_STR "/nwgbar/icon-missing.svg");
 
     if (!std::filesystem::is_regular_file(css_file)) {
         css_file = default_css_file;
@@ -298,7 +298,7 @@ int main(int argc, char *argv[]) {
 
     // The most expensive part
     for (std::size_t i = 0; i < desktop_entries.size(); i++) {
-        images[i] = app_image(icon_theme_ref, desktop_entries[i].icon);
+        images[i] = app_image(icon_theme_ref, desktop_entries[i].icon, icon_missing);
     }
 
     gettimeofday(&tp, NULL);

--- a/grid/grid.cc
+++ b/grid/grid.cc
@@ -136,8 +136,9 @@ int main(int argc, char *argv[]) {
     }
     std::cout << "Locale: " << lang << "\n";
 
+    auto cache_home = get_cache_home();
     if (favs) {
-        cache_file = get_cache_path();
+        cache_file = cache_home / "nwg-fav-cache";
         try {
             cache = get_cache(cache_file);
         }  catch (...) {
@@ -152,7 +153,7 @@ int main(int argc, char *argv[]) {
     }
 
     if (pins) {
-        pinned_file = get_pinned_path();
+        pinned_file = cache_home / "nwg-pin-cache";
         pinned = get_pinned(pinned_file);
         if (pinned.size() > 0) {
           std::cout << pinned.size() << " pinned entries loaded\n";

--- a/grid/grid.h
+++ b/grid/grid.h
@@ -152,11 +152,9 @@ struct CacheEntry {
 /*
  * Function declarations
  * */
+fs::path                    get_cache_home();
 ns::json                    get_cache(const std::string&);
-std::string                 get_cache_path(void);
-std::string                 get_pinned_path(void);
 std::vector<std::string>    get_app_dirs(void);
-std::vector<std::string>    list_entries(const std::vector<std::string>&);
 std::vector<std::string>    get_pinned(const std::string&);
 std::vector<CacheEntry>     get_favourites(ns::json&&, int);
 std::optional<DesktopEntry> desktop_entry(std::string&&, const std::string&);

--- a/grid/grid.h
+++ b/grid/grid.h
@@ -114,7 +114,7 @@ GridBox& MainWindow::emplace_box(Args&& ... args) {
 }
 
 struct CacheEntry {
-    std::string exec;
+    std::string desktop_id;
     int clicks;
     CacheEntry(std::string, int);
 };

--- a/grid/grid.h
+++ b/grid/grid.h
@@ -60,7 +60,7 @@ class GridBox : public Gtk::Button {
 public:
     /* name, comment, desktop-id, index */
     GridBox(Glib::ustring, Glib::ustring, const std::string& id, std::size_t);
-    ~GridBox();
+    ~GridBox() = default;
     bool on_button_press_event(GdkEventButton*) override;
     bool on_focus_in_event(GdkEventFocus*) override;
     void on_enter() override;

--- a/grid/grid.h
+++ b/grid/grid.h
@@ -52,9 +52,11 @@ struct Stats {
         Pinned = 1,
     };
     int    clicks;
+    int    position;
     FavTag favorite;
     PinTag pinned;
-    Stats(int c, FavTag f, PinTag p): clicks(c), favorite(f), pinned(p) { }
+    Stats(int c, int i, FavTag f, PinTag p)
+      : clicks(c), position(i), favorite(f), pinned(p) { }
 };
 
 class GridBox : public Gtk::Button {
@@ -122,6 +124,7 @@ class MainWindow : public CommonWindow {
         Span<std::string> execs;
         Span<Stats>       stats;
 
+        int  monotonic_index;       // to keep pins in order, see grid_classes.cc comment
         bool pins_changed = false;
         bool is_filtered = false;
 

--- a/grid/grid.h
+++ b/grid/grid.h
@@ -33,6 +33,7 @@ extern std::vector<std::string> pinned;
 extern ns::json cache;
 extern std::string cache_file;
 
+/* Primitive version of C++20's std::span */
 template <typename T>
 struct Span {
     Span(const Span& s) = default;
@@ -66,10 +67,10 @@ public:
     void on_enter() override;
     void on_activate() override;
 
-    Glib::ustring       name;
-    Glib::ustring       comment;
-    const std::string*  desktop_id;
-    std::size_t         index;
+    Glib::ustring      name;
+    Glib::ustring      comment;
+    const std::string* desktop_id; // ptr to desktop-id, never null
+    std::size_t        index;      // row index
 };
 
 class MainWindow : public CommonWindow {
@@ -113,8 +114,8 @@ class MainWindow : public CommonWindow {
         bool on_button_press_event(GdkEventButton*) override;
     private:
         std::list<GridBox>    all_boxes {};      // stores all applications buttons
-        std::vector<GridBox*> apps_boxes {};     // boxes attached to apps_grid
-        std::vector<GridBox*> filtered_boxes {}; // filtered boxes from
+        std::vector<GridBox*> apps_boxes {};     // all common boxes
+        std::vector<GridBox*> filtered_boxes {}; // common boxes meeting search criteria
         std::vector<GridBox*> fav_boxes {};      // attached to favs_grid
         std::vector<GridBox*> pinned_boxes {};   // attached to pinned_grid
 

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -103,8 +103,7 @@ bool MainWindow::on_button_press_event(GdkEventButton *event) {
 }
 
 bool MainWindow::on_key_press_event(GdkEventKey* key_event) {
-    auto key_val = key_event -> keyval;
-    switch (key_val) {
+    switch (key_event->keyval) {
         case GDK_KEY_Escape:
             this->close();
             break;
@@ -301,13 +300,13 @@ void MainWindow::save_cache() {
     if (favs) {
         ns::json favs_cache;
         // find min positive clicks count
-        decltype(Stats::clicks) min = 10000;
+        decltype(Stats::clicks) min = 1000000; // avoid including <limits>
         for (auto& box : this->all_boxes) {
             if (auto clicks = stats_of(box).clicks; clicks > 0) {
                 min = std::min(min, clicks);
             }
         }
-        // only save positives, substract min from them to keep clicks low, but preserve order
+        // only save positives, substract min to keep clicks low, but preserve order
         for (auto& box : this->all_boxes) {
             if (auto clicks = stats_of(box).clicks - min + 1; clicks > 0) {
                 favs_cache[*box.desktop_id] = clicks;
@@ -332,7 +331,6 @@ GridBox::GridBox(Glib::ustring name, Glib::ustring comment, const std::string& i
    this->set_always_show_image(true);
    this->set_label(this->name);
 }
-GridBox::~GridBox() { }
 
 bool GridBox::on_button_press_event(GdkEventButton* event) {
     auto& toplevel = *dynamic_cast<MainWindow*>(this -> get_toplevel());

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -308,6 +308,9 @@ void MainWindow::toggle_pinned(GridBox& box) {
  * */
 void MainWindow::save_cache() {
     if (pins_changed) {
+        std::sort(pinned_boxes.begin(), pinned_boxes.end(), [this](auto* a, auto* b) {
+            return this->stats_of(*a).position < this->stats_of(*b).position;
+        });
         std::ofstream out(pinned_file, std::ios::trunc);
         for (auto* pin : this->pinned_boxes) {
             out << *pin->desktop_id << '\n';

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -17,6 +17,7 @@
 #include "nwg_tools.h"
 #include "grid.h"
 
+// we only store GridBoxes inside of our FlowBoxes, so dynamic_cast won't fail
 inline auto child_ = [](auto c) -> auto& { return *dynamic_cast<GridBox*>(c->get_child()); };
 int by_name(Gtk::FlowBoxChild* a, Gtk::FlowBoxChild* b) {
     return child_(a).name.compare(child_(b).name);
@@ -147,9 +148,8 @@ inline auto refresh_max_children_per_line = [](auto& flowbox, auto& container) {
         flowbox.set_max_children_per_line(std::min(size, cols));
     }
 };
-/*
- * Populate grid with widgets from container
- * */
+
+/* Populate grid with widgets from container */
 inline auto build_grid = [](auto& grid, auto& container) {
     for (auto child : container) {
         grid.add(*child);
@@ -158,6 +158,7 @@ inline auto build_grid = [](auto& grid, auto& container) {
     refresh_max_children_per_line(grid, container);
 };
 
+/* Called each time `search_entry` changes, rebuilds `apps_grid` according to search criteria */
 void MainWindow::filter_view() {
     auto clean_grid = [](auto& grid) {
         grid.foreach([&grid](auto& child) {
@@ -192,6 +193,7 @@ void MainWindow::filter_view() {
     apps_grid.thaw_child_notify();
 }
 
+/* Sets separators' visibility according to grid status */
 void MainWindow::refresh_separators() {
     auto set_shown = [](auto c, auto& s) { if (c) s.show(); else s.hide(); };
     auto p = !pinned_boxes.empty();
@@ -334,7 +336,7 @@ GridBox::GridBox(Glib::ustring name, Glib::ustring comment, const std::string& i
 
 bool GridBox::on_button_press_event(GdkEventButton* event) {
     auto& toplevel = *dynamic_cast<MainWindow*>(this -> get_toplevel());
-    if (pins && event->button == 3) {
+    if (pins && event->button == 3) { // right-clicked
         toplevel.toggle_pinned(*this);
     } else {
         this -> activate();

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -22,13 +22,15 @@ inline auto child_ = [](auto c) -> auto& { return *dynamic_cast<GridBox*>(c->get
 int by_name(Gtk::FlowBoxChild* a, Gtk::FlowBoxChild* b) {
     return child_(a).name.compare(child_(b).name);
 }
+// return -1 if a < b, 0 if a == b, 1 if a > b
+inline auto cmp_ = [](auto a, auto b) { return int(a > b) - int(a < b); };
 int by_position(Gtk::FlowBoxChild* a, Gtk::FlowBoxChild* b) {
     auto& toplevel = *dynamic_cast<MainWindow*>(a->get_toplevel());
-    return toplevel.stats_of(child_(a)).position > toplevel.stats_of(child_(b)).position;
+    return cmp_(toplevel.stats_of(child_(a)).position, toplevel.stats_of(child_(b)).position);
 }
 int by_clicks(Gtk::FlowBoxChild* a, Gtk::FlowBoxChild* b) {
     auto& toplevel = *dynamic_cast<MainWindow*>(a->get_toplevel());
-    return toplevel.stats_of(child_(a)).clicks < toplevel.stats_of(child_(b)).clicks;
+    return cmp_(toplevel.stats_of(child_(a)).clicks, toplevel.stats_of(child_(b)).clicks);
 }
 MainWindow::MainWindow(Span<std::string> es, Span<Stats> ss)
  : CommonWindow("~nwggrid", "~nwggrid"), execs(es), stats(ss)

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -239,10 +239,17 @@ void MainWindow::build_grids() {
 }
 
 void MainWindow::focus_first_box() {
-    std::array containers{ &filtered_boxes, &pinned_boxes, &fav_boxes, &apps_boxes };
-    for (auto container : containers) {
-        if (container->size() > 0) {
-            container->front()->grab_focus();
+    // flowbox -> flowboxchild -> gridbox
+    if (is_filtered) {
+        if (auto child = apps_grid.get_child_at_index(0)) {
+            child->get_child()->grab_focus();
+            return;
+        }
+    }
+    std::array grids { &pinned_grid,  &favs_grid, &apps_grid };
+    for (auto grid : grids) {
+        if (auto child = grid->get_child_at_index(0)) {
+            child->get_child()->grab_focus();
             return;
         }
     }

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -243,13 +243,13 @@ void MainWindow::toggle_pinned(GridBox& box) {
     // disable prelight
     box.unset_state_flags(Gtk::STATE_FLAG_PRELIGHT);
 
-    auto is_pinned = box.pinned == GridBox::Pinned;
-    box.pinned = GridBox::PinTag{ !is_pinned };
+    auto is_pinned = box.stats().pinned == Stats::Pinned;
+    box.stats().pinned = Stats::PinTag{ !is_pinned };
 
     auto* from_grid = &this->apps_grid;
     auto* from = &this->apps_boxes;
 
-    if (box.favorite) {
+    if (box.stats().favorite) {
         from_grid = &this->favs_grid;
         from = &this->fav_boxes;
     }
@@ -299,8 +299,8 @@ bool MainWindow::has_fav_with_exec(const std::string& exec) const {
 }
 
 // This constructor is not needed since C++20
-GridBox::GridBox(Glib::ustring name, Glib::ustring exec, Glib::ustring comment, GridBox::FavTag fav, GridBox::PinTag pinned)
- : AppBox(std::move(name), std::move(exec), std::move(comment)), favorite(fav), pinned(pinned) {}
+GridBox::GridBox(Glib::ustring name, Glib::ustring exec, Glib::ustring comment, Stats& stats)
+ : AppBox(std::move(name), std::move(exec), std::move(comment)), _stats(&stats) { }
 
 bool GridBox::on_button_press_event(GdkEventButton* event) {
     if (pins && event->button == 3) {
@@ -315,8 +315,6 @@ bool GridBox::on_button_press_event(GdkEventButton* event) {
             clicks = 1;
         }
         cache[exec] = clicks;
-        save_json(cache, cache_file);    
-
         this -> activate();
     }
     return AppBox::on_button_press_event(event);

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -30,7 +30,7 @@ int by_position(Gtk::FlowBoxChild* a, Gtk::FlowBoxChild* b) {
 }
 int by_clicks(Gtk::FlowBoxChild* a, Gtk::FlowBoxChild* b) {
     auto& toplevel = *dynamic_cast<MainWindow*>(a->get_toplevel());
-    return cmp_(toplevel.stats_of(child_(a)).clicks, toplevel.stats_of(child_(b)).clicks);
+    return -cmp_(toplevel.stats_of(child_(a)).clicks, toplevel.stats_of(child_(b)).clicks);
 }
 MainWindow::MainWindow(Span<std::string> es, Span<Stats> ss)
  : CommonWindow("~nwggrid", "~nwggrid"), execs(es), stats(ss)

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -326,9 +326,9 @@ bool MainWindow::on_delete_event(GdkEventAny* event) {
 GridBox::GridBox(Glib::ustring name, Glib::ustring comment, const std::string& id, std::size_t index)
 : name(std::move(name)), comment(std::move(comment)), desktop_id(&id), index(index)
 {
-   if (name.length() > 25) {
-       name.resize(22);
-       name += "...";
+   if (this->name.length() > 25) {
+       this->name.resize(22);
+       this->name += "...";
    }
    this->set_always_show_image(true);
    this->set_label(this->name);

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -177,8 +177,8 @@ void MainWindow::filter_view() {
         };
         for (auto* box : apps_boxes) {
             auto& exec = this->exec_of(*box);
-            auto exec_matches = exec.find(phrase) != std::string::npos;
-            if (matches(box->name) || exec_matches || matches(box->comment)) {
+            auto matches_exec = exec.find(phrase) != std::string::npos;
+            if (matches(box->name) || matches_exec || matches(box->comment)) {
                 filtered_boxes.push_back(box);
             }
         }

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -17,10 +17,12 @@
 #include "nwg_tools.h"
 #include "grid.h"
 
-int by_name(Gtk::FlowBoxChild* a_, Gtk::FlowBoxChild* b_) {
-    auto a = dynamic_cast<GridBox*>(a_->get_child());
-    auto b = dynamic_cast<GridBox*>(b_->get_child());
-    return a->name.compare(b->name);
+inline auto child_ = [](auto c) -> auto& { return *dynamic_cast<GridBox*>(c->get_child()); };
+int by_name(Gtk::FlowBoxChild* a, Gtk::FlowBoxChild* b) {
+    return child_(a).name.compare(child_(b).name);
+}
+int by_clicks(Gtk::FlowBoxChild* a, Gtk::FlowBoxChild* b) {
+    return child_(a).stats().clicks < child_(b).stats().clicks;
 }
 
 MainWindow::MainWindow()
@@ -44,6 +46,7 @@ MainWindow::MainWindow()
     setup_grid(favs_grid);
     setup_grid(pinned_grid);
     apps_grid.set_sort_func(&by_name);
+    favs_grid.set_sort_func(&by_clicks);
 
     description.set_text("");
     description.set_name("description");
@@ -139,7 +142,7 @@ bool MainWindow::on_key_press_event(GdkEventKey* key_event) {
 inline auto refresh_max_children_per_line = [](auto& flowbox, auto& container) {
     auto size = container.size();
     decltype(size) cols = num_col;
-    if (auto min = std::min(cols, size)) {
+    if (auto min = std::min(cols, size)) { // suppress gtk warnings about size=0
         flowbox.set_min_children_per_line(std::min(size, cols));
         flowbox.set_max_children_per_line(std::min(size, cols));
     }

--- a/grid/grid_tools.cc
+++ b/grid/grid_tools.cc
@@ -13,7 +13,7 @@
 #include "nwg_tools.h"
 #include "grid.h"
 
-CacheEntry::CacheEntry(std::string exec, int clicks): exec(std::move(exec)), clicks(clicks) { }
+CacheEntry::CacheEntry(std::string desktop_id, int clicks): desktop_id(std::move(desktop_id)), clicks(clicks) { }
 
 /*
  * Returns cache file path
@@ -193,6 +193,9 @@ std::optional<DesktopEntry> desktop_entry(std::string&& path, const std::string&
     }
     if (!comment_ln.empty()) {
         entry.comment = std::move(comment_ln);
+    }
+    if (entry.name.empty() || entry.exec.empty()) {
+        return std::nullopt;
     }
     return entry;
 }


### PR DESCRIPTION
Goals reached:
 - Respect `NoDisplay=true` setting in saner way
 - Separate widgets from data

Breaking changes:
 - Use desktop-id instead of exec to distinguish entries from each other. This breaks existing pins/favs cache. **Old caches will be overwritten after the first launch**.

The following goals are to be reached before opening full-fledged PR.
- [ ] Write proper description;
- [ ] Polish everything;
- [ ] Find and fix bugs;
- [ ] Make sure it works well everywhere.
