### PR TITLE
Check optional value before dereferencing.

### DIFF
--- a/grid/grid.cc
+++ b/grid/grid.cc
@@ -308,7 +308,8 @@ int main(int argc, char *argv[]) {
     long int boxes_ms = tp.tv_sec * 1000 + tp.tv_usec / 1000;
 
     for (auto& [desktop_id, pos_] : desktop_ids) {
-        if (auto pos = *pos_; pos_) {
+        if (pos_) {
+            auto pos = *pos_;
             auto& entry = desktop_entries[pos];
             auto& ab = window.emplace_box(std::move(entry.name),
                                           std::move(entry.comment),


### PR DESCRIPTION
Dereferencing empty std::optional is UB and would fail under certain
conditions. One of them is a compilation with -D_GLIBCXX_ASSERTIONS
which enables additional internal checks in libstdc++.

Fixes following crash in nwggrid:
/usr/include/c++/10/optional:441: constexpr _Tp& std::_Optional_base_impl<_Tp, _Dp>::_M_get() [with _Tp = long unsigned int; _Dp = std::_Optional_base<long unsigned int, true, true>]: Assertion 'this->_M_is_engaged()' failed.