### PR TITLE
Add TravisCI for GCC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 language: cpp
+dist: focal
 
 os:
+  - linux   # gcc/libstdc++
   - freebsd # clang/libc++
 
 before_install:
+  - |
+    if [ "$TRAVIS_OS_NAME" = linux ]; then
+      sudo apt-get install -y python3-pip python3-setuptools ninja-build libgtkmm-3.0-dev nlohmann-json3-dev
+      sudo pip3 install meson
+    fi
   - |
     if [ "$TRAVIS_OS_NAME" = freebsd ]; then
       sudo pkg install -y meson pkgconf gtkmm30 nlohmann-json

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ os:
   - freebsd # clang/libc++
 
 before_install:
-  - sudo pkg install -y meson pkgconf gtkmm30 nlohmann-json
+  - |
+    if [ "$TRAVIS_OS_NAME" = freebsd ]; then
+      sudo pkg install -y meson pkgconf gtkmm30 nlohmann-json
+    fi
 
 script:
   - meson _build


### PR DESCRIPTION
Requested in https://github.com/nwg-piotr/nwg-launchers/issues/109#issuecomment-692169321

I'm not familar with Linux. Testing on non-Ubuntu probably requires docker ([example](https://github.com/Alexays/Waybar/blob/a1f6e386240e/.travis.yml)) or chroot ([example](https://github.com/francma/wob/blob/45ff23262e49/.travis.yml)).
