### PR TITLE
Add support for mnemonics in nwgbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,23 @@ Templates use json format. The default one defines an example Exit menu for sway
 ]
 ```
 
+To set a keyboard shortcut (using Alt+KEY) for an entry, you can add an underscore before the letter you want to use. Example to set `s` as the shortcut:
+```
+[
+...
+  {
+    "name": "Lock _screen",
+    "exec": "swaylock -f -c 000000",
+    "icon": "system-lock-screen"
+  }
+...
+]
+```
+
+**Note for underscore ("_")**
+
+If you want to use an underscore in the name, you have to double it ("__").
+
 **Wayfire note**
 
 For the Logout button, as in the bar above, you may use [wayland-logout](https://github.com/soreau/wayland-logout) by @soreau.

--- a/common/nwg_classes.cc
+++ b/common/nwg_classes.cc
@@ -79,7 +79,7 @@ AppBox::AppBox() {
     this -> set_always_show_image(true);
 }
 
-AppBox::AppBox(Glib::ustring name, Glib::ustring exec, Glib::ustring comment) {
+AppBox::AppBox(Glib::ustring name, Glib::ustring exec, Glib::ustring comment) : Gtk::Button(name, true) {
     this -> name = name;
     if (name.length() > 25) {
         name = name.substr(0, 22) + "...";
@@ -87,7 +87,6 @@ AppBox::AppBox(Glib::ustring name, Glib::ustring exec, Glib::ustring comment) {
     this -> exec = std::move(exec);
     this -> comment = std::move(comment);
     this -> set_always_show_image(true);
-    this -> set_label(name);
 }
 
 AppBox::~AppBox() {


### PR DESCRIPTION
This adds support for mnemonics, which includes the possibility to use accelerator keys ([https://developer.gnome.org/gtk3/unstable/GtkButton.html#gtk-button-new-with-mnemonic](docs)).