### PR TITLE
`-d` colon instead of space as the separator #122

### DIFF
--- a/grid/grid.cc
+++ b/grid/grid.cc
@@ -35,7 +35,7 @@ Options:\n\
 -h               show this help message and exit\n\
 -f               display favourites (most used entries); does not work with -d\n\
 -p               display pinned entries; does not work with -d \n\
--d               look for .desktop files in custom paths (-d '/my/path1 /my/path2'); '~/' not supported \n\
+-d               look for .desktop files in custom paths (-d '/my/path1:/my/another path:/third/path') \n\
 -o <opacity>     default (black) background opacity (0.0 - 1.0, default 0.9)\n\
 -b <background>  background colour in RRGGBB or RRGGBBAA format (RRGGBBAA alpha overrides <opacity>)\n\
 -n <col>         number of grid columns (default: 6)\n\
@@ -197,7 +197,7 @@ int main(int argc, char *argv[]) {
         dirs = get_app_dirs();
     } else {
         // use special dirs specified with -d argument (feature request #122)
-        dirs = split_string(special_dirs, " ");
+        dirs = split_string(special_dirs, ":");
     }
 
     gettimeofday(&tp, NULL);


### PR DESCRIPTION
From now on the proper format is `-d '/my/path1:/my/another path:/third/path'` #122 