### PR TITLE
opening in terminal added; sorting long names fixed

### DIFF
--- a/common/nwg_classes.h
+++ b/common/nwg_classes.h
@@ -76,6 +76,7 @@ struct DesktopEntry {
     std::string icon;
     std::string comment;
     std::string mime_type;
+    bool terminal;
 };
 
 struct RGBA {

--- a/common/nwg_tools.cc
+++ b/common/nwg_tools.cc
@@ -98,23 +98,25 @@ std::string detect_wm() {
         t = read_file_to_string(term_file);
         t.erase(remove(t.begin(), t.end(), '\n'), t.end());
     } else {
-        // We'll only look for terminals that return 0 exit code from the '<terminal> -v' command.
-        // First one found will be saved to the '~/.config/nwg-launchers/nwggrid/term' file.
+        // We'll look for the first terminal available and save its name to '~/.config/nwg-launchers/nwggrid/term'.
         // User may change the file content (terminal name) to their liking.
-        std::string checks [] = {
-            "alacritty -V",
-            "kitty -v",
-            "lxterminal -v",
-            "xfce4-terminal -V",
-            "termite -v",
-            "terminator -v"
+        std::string terms [] = {
+            "alacritty",
+            "kitty",
+            "lxterminal",
+            "sakura",
+            "st",
+            "termite",
+            "terminator",
+            "xfce4-terminal",
+            "gnome-terminal"
         };
-        for (auto&& check : checks) {
-            check = check + " &>/dev/null";
+        for (auto&& term : terms) {
+            std::string check = "command -v " + term + " &>/dev/null";
             const char *command = check.c_str();
             int status = std::system(command);
             if (status == 0) {
-                t = split_string(check, " ")[0];
+                t = term;
                 std::string cmd = "echo " + t + " > " + term_file;
                 const char *c = cmd.c_str();
                 std::system(c);

--- a/common/nwg_tools.cc
+++ b/common/nwg_tools.cc
@@ -88,6 +88,48 @@ std::string detect_wm() {
 }
 
 /*
+ * Detect installed terminal emulator
+ *
+ * */
+ std::string get_term(std::string config_dir) {
+    std::string t{"xterm"};
+    std::string term_file = config_dir + "/term";
+    if (std::ifstream(term_file)) {
+        t = read_file_to_string(term_file);
+        t.erase(remove(t.begin(), t.end(), '\n'), t.end());
+    } else {
+        std::string checks [] = {
+            "alacritty -V",
+            "kitty -v",
+            "lxterminal -v",
+            "xfce4-terminal -V",
+            "termite -v",
+            "terminator -v"
+        };
+        for (auto&& check : checks) {
+            check = check + " &>/dev/null";
+            const char *command = check.c_str();
+            int status = std::system(command);
+            if (status == 0) {
+                t = split_string(check, " ")[0];
+                std::string cmd = "echo " + t + " > " + term_file;
+                const char *c = cmd.c_str();
+                std::system(c);
+                std::cout << "Saving \'" << t << "\' to \'" << term_file << "\' - edit to use another terminal.\n";
+                break;
+            }
+        }
+        if (!std::ifstream(term_file)) {
+            std::cout << "No known terminal found. Saving \'xterm\' to \'" << term_file << "\'.\n";
+            std::string cmd = "echo " + t + " > " + term_file;
+            const char *c = cmd.c_str();
+            std::system(c);
+        }
+    }
+    return t;
+ }
+
+/*
  * Returns x, y, width, hight of focused display
  * */
 Geometry display_geometry(const std::string& wm, Glib::RefPtr<Gdk::Display> display, Glib::RefPtr<Gdk::Window> window) {
@@ -309,7 +351,6 @@ std::string get_output(const std::string& cmd) {
     }
     return result;
 }
-
 
 /*
  * Remove pid_file created by create_pid_file_or_kill_pid.

--- a/common/nwg_tools.cc
+++ b/common/nwg_tools.cc
@@ -88,16 +88,19 @@ std::string detect_wm() {
 }
 
 /*
- * Detect installed terminal emulator
- *
+ * Detect installed terminal emulator, save the command to txt file.
+ * If none found, 'xterm' is our fallback value.
  * */
  std::string get_term(std::string config_dir) {
     std::string t{"xterm"};
     std::string term_file = config_dir + "/term";
     if (std::ifstream(term_file)) {
+        // File exists: read command from the file, skip checks
         t = read_file_to_string(term_file);
         t.erase(remove(t.begin(), t.end(), '\n'), t.end());
     } else {
+        // We'll only look for terminals that return 0 exit code from the '<terminal> -v' command.
+        // First one found will be saved to the ''~/.config/nwg-launchers/nwggrid/term' file.
         std::string checks [] = {
             "alacritty -V",
             "kitty -v",

--- a/common/nwg_tools.cc
+++ b/common/nwg_tools.cc
@@ -103,6 +103,7 @@ std::string detect_wm() {
         std::string terms [] = {
             "alacritty",
             "kitty",
+            "urxvt",
             "lxterminal",
             "sakura",
             "st",

--- a/common/nwg_tools.cc
+++ b/common/nwg_tools.cc
@@ -88,8 +88,7 @@ std::string detect_wm() {
 }
 
 /*
- * Detect installed terminal emulator, save the command to txt file.
- * If none found, 'xterm' is our fallback value.
+ * Detect installed terminal emulator, save the command to txt file for further use.
  * */
  std::string get_term(std::string config_dir) {
     std::string t{"xterm"};
@@ -100,7 +99,8 @@ std::string detect_wm() {
         t.erase(remove(t.begin(), t.end(), '\n'), t.end());
     } else {
         // We'll only look for terminals that return 0 exit code from the '<terminal> -v' command.
-        // First one found will be saved to the ''~/.config/nwg-launchers/nwggrid/term' file.
+        // First one found will be saved to the '~/.config/nwg-launchers/nwggrid/term' file.
+        // User may change the file content (terminal name) to their liking.
         std::string checks [] = {
             "alacritty -V",
             "kitty -v",
@@ -122,6 +122,8 @@ std::string detect_wm() {
                 break;
             }
         }
+        // In case we've found nothing, 'xterm' will be saved to the '~/.config/nwg-launchers/nwggrid/term' file,
+        // regardless of whether it is installed or not. User may still edit the file.
         if (!std::ifstream(term_file)) {
             std::cout << "No known terminal found. Saving \'xterm\' to \'" << term_file << "\'.\n";
             std::string cmd = "echo " + t + " > " + term_file;

--- a/common/nwg_tools.h
+++ b/common/nwg_tools.h
@@ -31,6 +31,8 @@ std::string get_config_dir(std::string);
 
 std::string detect_wm(void);
 
+std::string get_term(std::string);
+
 std::string get_locale(void);
 
 std::string read_file_to_string(const std::string&);

--- a/grid/grid.cc
+++ b/grid/grid.cc
@@ -21,6 +21,7 @@
 bool pins = false;              // whether to display pinned
 bool favs = false;              // whether to display favorites
 std::string wm {""};            // detected or forced window manager name
+std::string term {""};
 std::size_t num_col = 6;        // number of grid columns
 RGBA background = {0.0, 0.0, 0.0, 0.9};
 
@@ -171,6 +172,8 @@ int main(int argc, char *argv[]) {
         std::cout << "Config dir not found, creating...\n";
         fs::create_directories(config_dir);
     }
+
+    term = get_term(config_dir);
 
     // default and custom style sheet
     std::string default_css_file = config_dir + "/style.css";

--- a/grid/grid.h
+++ b/grid/grid.h
@@ -32,6 +32,7 @@ extern std::string pinned_file;
 extern std::vector<std::string> pinned;
 extern ns::json cache;
 extern std::string cache_file;
+extern std::string term;
 
 /* Primitive version of C++20's std::span */
 template <typename T>

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -388,7 +388,7 @@ void GridBox::on_activate() {
     std::string cmd = toplevel.exec_of(*this);
     cmd += " &";
     if (cmd.find(term) == 0) {
-        std::cout << "Running command in " << term << "\n";
+        std::cout << "Running: \'" << cmd << "\'\n";
     }
     std::system(cmd.data());
     toplevel.close();

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -348,14 +348,16 @@ bool MainWindow::on_delete_event(GdkEventAny* event) {
 }
 
 GridBox::GridBox(Glib::ustring name, Glib::ustring comment, const std::string& id, std::size_t index)
-: name(std::move(name)), comment(std::move(comment)), desktop_id(&id), index(index)
-{
-   if (this->name.length() > 25) {
-       this->name.resize(22);
-       this->name += "...";
-   }
-   this->set_always_show_image(true);
-   this->set_label(this->name);
+: name(std::move(name)), comment(std::move(comment)), desktop_id(&id), index(index) {
+    // As we sort dynamically by actual names, we need to avoid shortening them, or long names will remain unsorted.
+    // See the issue: https://github.com/nwg-piotr/nwg-launchers/issues/128
+    std::string display_name = this->name;
+    if (display_name.length() > 25) {
+       display_name.resize(22);
+       display_name += "...";
+    }
+    this->set_always_show_image(true);
+    this->set_label(display_name);
 }
 
 bool GridBox::on_button_press_event(GdkEventButton* event) {

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -86,7 +86,7 @@ MainWindow::MainWindow(Span<std::string> es, Span<Stats> ss)
     inner_vbox.set_halign(Gtk::ALIGN_CENTER);
     inner_vbox.pack_start(pinned_hbox, Gtk::PACK_SHRINK, 5);
     inner_vbox.pack_start(separator1, false, true, 0);
-    
+
     favs_hbox.pack_start(favs_grid, true, false, 0);
     inner_vbox.pack_start(favs_hbox, false, false, 5);
     inner_vbox.pack_start(separator, false, true, 0);
@@ -98,7 +98,7 @@ MainWindow::MainWindow(Span<std::string> es, Span<Stats> ss)
     scrolled_window.show_all_children();
 
     outer_vbox.pack_start(description, Gtk::PACK_SHRINK);
-    
+
     this -> add(outer_vbox);
     this -> show_all_children();
 }
@@ -136,7 +136,7 @@ bool MainWindow::on_key_press_event(GdkEventKey* key_event) {
                 // so we make sure to drop the selection
                 this -> searchbox.select_region(0, 0);
                 this -> searchbox.set_position(-1);
-            
+
             }
     }
     // Delegate handling to the base class
@@ -269,7 +269,7 @@ void MainWindow::toggle_pinned(GridBox& box) {
     auto& stats = this->stats_of(box);
     auto is_pinned = stats.pinned == Stats::Pinned;
     stats.pinned = Stats::PinTag{ !is_pinned };
-    
+
     // monotonic index increases each time an entry is pinned
     // ensuring it will appear last
     stats.position = this->monotonic_index * !is_pinned;
@@ -294,7 +294,7 @@ void MainWindow::toggle_pinned(GridBox& box) {
     to->push_back(&box);
     refresh_max_children_per_line(*from_grid, *from);
     refresh_max_children_per_line(*to_grid, *to);
-    
+
     // get_parent is important
     // FlowBox { ... FlowBoxChild { box } ... }
     // box is not child to FlowBox
@@ -387,6 +387,9 @@ void GridBox::on_activate() {
     toplevel.stats_of(*this).clicks++;
     std::string cmd = toplevel.exec_of(*this);
     cmd += " &";
+    if (cmd.find(term) == 0) {
+        std::cout << "Running command in " << term << "\n";
+    }
     std::system(cmd.data());
     toplevel.close();
 }

--- a/grid/grid_tools.cc
+++ b/grid/grid_tools.cc
@@ -142,6 +142,7 @@ std::optional<DesktopEntry> desktop_entry(std::string&& path, const std::string&
     }
     // Repeat until the next section
     constexpr auto nodisplay = "NoDisplay=true"sv;
+    constexpr auto terminal = "Terminal=true"sv;
     while (std::getline(file, str)) {
         if (str[0] == '[') { // new section begins, break
             break;
@@ -150,6 +151,9 @@ std::optional<DesktopEntry> desktop_entry(std::string&& path, const std::string&
         auto view_len = std::size(view);
         if (view == nodisplay) {
             return std::nullopt;
+        }
+        if (view == terminal) {
+            entry.terminal = true;
         }
         auto try_strip_prefix = [&view, view_len](auto& prefix) {
             auto len = std::min(view_len, std::size(prefix));
@@ -184,6 +188,9 @@ std::optional<DesktopEntry> desktop_entry(std::string&& path, const std::string&
     }
     if (entry.name.empty() || entry.exec.empty()) {
         return std::nullopt;
+    }
+    if (entry.terminal) {
+        entry.exec = term + " -e " + entry.exec;
     }
     return entry;
 }


### PR DESCRIPTION
Changes to nwggrid:

- added detection of installed terminal emulator and opening apps w/ the `Terminal=true` line #127 
- fixed sorting names longer than 25 characters #128 