### PR TITLE
Initialise entry.terminal to false.

### DIFF
--- a/grid/grid_tools.cc
+++ b/grid/grid_tools.cc
@@ -101,6 +101,7 @@ std::optional<DesktopEntry> desktop_entry(std::string&& path, const std::string&
     using namespace std::literals::string_view_literals;
 
     DesktopEntry entry;
+    entry.terminal = false;
 
     std::ifstream file(path);
     std::string str;


### PR DESCRIPTION
The bool, terminal, in the DesktopEntry struct is uninitialised in grid_tools.cc: desktop_entry(). This results in applications randomly being opened in a terminal even if "Terminal=true" is not set in their .desktop file.