### PR TITLE
Use sway-ipc instead of calling swaymsg

### DIFF
--- a/bar/bar.cc
+++ b/bar/bar.cc
@@ -178,10 +178,8 @@ int main(int argc, char *argv[]) {
 
     /* turn off borders, enable floating on sway */
     if (wm == "sway") {
-        auto* cmd = "swaymsg for_window [title=\"~nwgbar*\"] floating enable";
-        std::system(cmd);
-        cmd = "swaymsg for_window [title=\"~nwgbar*\"] border none";
-        std::system(cmd);
+        SwaySock sock;
+        sock.run("for_window [title=\"~nwgbar*\"] floating enable,border none");
     }
 
     Gtk::Main kit(argc, argv);

--- a/common/nwg_tools.cc
+++ b/common/nwg_tools.cc
@@ -212,16 +212,15 @@ std::string SwaySock::get_outputs() {
  * Throws `SwayError::Recv{Header,Body}Failed`
  */
 std::string SwaySock::recv_response_() {
-    char header[HEADER_SIZE];
     std::size_t total = 0;
     while (total < HEADER_SIZE) {
-        auto received = recv(sock_, header, HEADER_SIZE - total, 0);
+        auto received = recv(sock_, header.data(), HEADER_SIZE - total, 0);
         if (received < 0) {
             throw SwayError::RecvHeaderFailed;
         }
         total += received;
     }
-    auto payload_size = *(std::uint32_t*)(header + MAGIC_SIZE);
+    auto payload_size = *reinterpret_cast<std::uint32_t*>(header.data() + MAGIC_SIZE);
     std::string buffer(payload_size + 1, '\0');
     auto payload = buffer.data();
     total = 0;
@@ -232,7 +231,7 @@ std::string SwaySock::recv_response_() {
         }
         total += received;
     }
-    return buffer;    
+    return buffer;   
 }
 
 /*

--- a/common/nwg_tools.cc
+++ b/common/nwg_tools.cc
@@ -13,6 +13,8 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <signal.h>
+#include <sys/socket.h>
+#include <sys/un.h>
 
 #include <iostream>
 #include <fstream>
@@ -91,7 +93,7 @@ std::string detect_wm() {
 /*
  * Detect installed terminal emulator, save the command to txt file for further use.
  * */
- std::string get_term(std::string config_dir) {
+std::string get_term(std::string config_dir) {
     std::string t{"xterm -e"};
     std::string term_file = config_dir + "/term";
     std::string terminal_file = config_dir + "/terminal";
@@ -156,7 +158,95 @@ std::string detect_wm() {
         }
     }
     return t;
- }
+}
+ 
+/*
+ * Connects to Sway socket, loading socket info from $SWAYSOCK or $I3SOCK
+ * Throws SwayError
+ * - sway --get-socketpath is not supported (yet?)
+ * */
+SwaySock::SwaySock() {
+    auto path = getenv("SWAYSOCK");
+    if (!path) {
+        path = getenv("I3SOCK");
+        if (!path) {
+            throw SwayError::EnvNotSet;
+        }
+    }
+    path = strdup(path);
+
+    sock_ = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (sock_ == -1) {
+        free(path);
+        throw SwayError::OpenFailed;
+    }
+    
+    sockaddr_un addr;
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, path, sizeof(addr.sun_path) - 1);
+    addr.sun_path[sizeof(addr.sun_path) - 1] = 0;
+    if (connect(sock_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == -1) {
+        free(path);
+        throw SwayError::ConnectFailed;
+    }
+    free(path);
+}
+
+SwaySock::~SwaySock() {
+    if (close(sock_)) {
+        std::cerr << "ERROR: Unable to close socket\n";
+    }
+}
+
+/*
+ * Returns `swaymsg -t get_outputs`
+ * Throws `SwayError`
+ * */
+std::string SwaySock::get_outputs() {
+    char header[HEADER_SIZE];
+    make_header_(header, 0, Commands::GetOutputs);
+    
+    if (write(sock_, header, HEADER_SIZE) == -1) {
+        throw SwayError::SendHeaderFailed;
+    }
+
+    std::size_t total = 0;
+    while (total < HEADER_SIZE) {
+        auto received = recv(sock_, header, HEADER_SIZE - total, 0);
+        if (received < 0) {
+            throw SwayError::RecvHeaderFailed;
+        }
+        total += received;
+    }
+    auto payload_size = *(std::uint32_t*)(header + MAGIC_SIZE);
+    std::string buffer(payload_size + 1, '\0');
+    auto payload = buffer.data();
+    total = 0;
+    while (total < payload_size) {
+        auto received = recv(sock_, payload + total, payload_size - total, 0);
+        if (received < 0) {
+            throw SwayError::RecvBodyFailed;
+        }
+        total += received;
+    }
+    return buffer;    
+}
+
+/*
+ * Asks Sway to run `cmd`
+ * Throws `SwayError`
+ * */
+void SwaySock::run(std::string_view cmd) {
+    char header[HEADER_SIZE];
+    make_header_(header, cmd.size(), Commands::Run);
+    if (write(sock_, header, HEADER_SIZE) == -1) {
+        throw SwayError::SendHeaderFailed;
+    }
+    if (write(sock_, cmd.data(), cmd.size()) == -1) {
+        throw SwayError::SendBodyFailed;
+    }
+    // should we recv the response?
+}
 
 /*
  * Returns x, y, width, hight of focused display
@@ -165,7 +255,8 @@ Geometry display_geometry(const std::string& wm, Glib::RefPtr<Gdk::Display> disp
     Geometry geo = {0, 0, 0, 0};
     if (wm == "sway") {
         try {
-            auto jsonString = get_output("swaymsg -t get_outputs");
+            SwaySock sock;
+            auto jsonString = sock.get_outputs();
             auto jsonObj = string_to_json(jsonString);
             for (auto&& entry : jsonObj) {
                 if (entry.at("focused")) {

--- a/common/nwg_tools.cc
+++ b/common/nwg_tools.cc
@@ -203,13 +203,16 @@ SwaySock::~SwaySock() {
  * Throws `SwayError`
  * */
 std::string SwaySock::get_outputs() {
-    char header[HEADER_SIZE];
-    make_header_(header, 0, Commands::GetOutputs);
-    
-    if (write(sock_, header, HEADER_SIZE) == -1) {
-        throw SwayError::SendHeaderFailed;
-    }
+    send_header_(0, Commands::GetOutputs);
+    return recv_response_();
+}
 
+/*
+ * Returns output of previously issued command
+ * Throws `SwayError::Recv{Header,Body}Failed`
+ */
+std::string SwaySock::recv_response_() {
+    char header[HEADER_SIZE];
     std::size_t total = 0;
     while (total < HEADER_SIZE) {
         auto received = recv(sock_, header, HEADER_SIZE - total, 0);
@@ -234,18 +237,28 @@ std::string SwaySock::get_outputs() {
 
 /*
  * Asks Sway to run `cmd`
- * Throws `SwayError`
+ * Throws `SwayError::Send{Header,Body}Failed`
  * */
 void SwaySock::run(std::string_view cmd) {
-    char header[HEADER_SIZE];
-    make_header_(header, cmd.size(), Commands::Run);
-    if (write(sock_, header, HEADER_SIZE) == -1) {
+    send_header_(cmd.size(), Commands::Run);
+    send_body_(cmd);
+    // should we recv the response?
+    // suppress warning
+    (void)recv_response_();
+}
+
+void SwaySock::send_header_(std::uint32_t message_len, Commands command) {
+    memcpy(header.data(), MAGIC.data(), MAGIC_SIZE);
+    memcpy(header.data() + MAGIC_SIZE, &message_len, sizeof(message_len));
+    memcpy(header.data() + MAGIC_SIZE + sizeof(message_len), &command, sizeof(command));
+    if (write(sock_, header.data(), HEADER_SIZE) == -1) {
         throw SwayError::SendHeaderFailed;
     }
+}
+void SwaySock::send_body_(std::string_view cmd) {
     if (write(sock_, cmd.data(), cmd.size()) == -1) {
         throw SwayError::SendBodyFailed;
     }
-    // should we recv the response?
 }
 
 /*

--- a/common/nwg_tools.h
+++ b/common/nwg_tools.h
@@ -50,3 +50,43 @@ Gtk::Image* app_image(const Gtk::IconTheme&, const std::string&, const Glib::Ref
 Geometry display_geometry(const std::string&, Glib::RefPtr<Gdk::Display>, Glib::RefPtr<Gdk::Window>);
 
 void create_pid_file_or_kill_pid(std::string);
+
+enum class SwayError {
+    ConnectFailed,
+    EnvNotSet,
+    OpenFailed,
+    RecvHeaderFailed,
+    RecvBodyFailed,
+    SendHeaderFailed,
+    SendBodyFailed
+};
+
+struct SwaySock {
+    SwaySock();
+    SwaySock(const SwaySock&) = delete;
+    ~SwaySock();
+    // pass the command to sway via socket
+    void run(std::string_view);
+    // swaymsg -t get_outputs
+    std::string get_outputs();
+
+    int sock_;
+
+    // see sway-ipc (7)
+    enum class Commands: std::uint32_t {
+        Run = 0,
+        GetOutputs = 3
+    };
+    static constexpr std::array MAGIC { 'i', '3', '-', 'i', 'p', 'c' };
+    static constexpr auto MAGIC_SIZE = MAGIC.size();
+    // magic + body length (u32) + type (u32)
+    static constexpr auto HEADER_SIZE = MAGIC_SIZE + 2 * sizeof(std::uint32_t);
+    static inline auto make_header_ = [](char* header, std::uint32_t len, auto type) {
+        constexpr auto type_ = sizeof(type);
+        constexpr auto len_ = sizeof(len);
+        static_assert(type_ == sizeof(std::uint32_t));
+        memcpy(header, MAGIC.data(), MAGIC_SIZE);
+        memcpy(header + MAGIC_SIZE, &len, len_);
+        memcpy(header + MAGIC_SIZE + len_, &type, type_);
+    };
+};

--- a/common/nwg_tools.h
+++ b/common/nwg_tools.h
@@ -69,9 +69,7 @@ struct SwaySock {
     void run(std::string_view);
     // swaymsg -t get_outputs
     std::string get_outputs();
-
-    int sock_;
-
+    
     // see sway-ipc (7)
     enum class Commands: std::uint32_t {
         Run = 0,
@@ -81,12 +79,11 @@ struct SwaySock {
     static constexpr auto MAGIC_SIZE = MAGIC.size();
     // magic + body length (u32) + type (u32)
     static constexpr auto HEADER_SIZE = MAGIC_SIZE + 2 * sizeof(std::uint32_t);
-    static inline auto make_header_ = [](char* header, std::uint32_t len, auto type) {
-        constexpr auto type_ = sizeof(type);
-        constexpr auto len_ = sizeof(len);
-        static_assert(type_ == sizeof(std::uint32_t));
-        memcpy(header, MAGIC.data(), MAGIC_SIZE);
-        memcpy(header + MAGIC_SIZE, &len, len_);
-        memcpy(header + MAGIC_SIZE + len_, &type, type_);
-    };
+    
+    int                           sock_;
+    std::array<char, HEADER_SIZE> header;
+
+    void send_header_(std::uint32_t, Commands);
+    void send_body_(std::string_view);
+    std::string recv_response_();
 };

--- a/dmenu/dmenu.cc
+++ b/dmenu/dmenu.cc
@@ -199,10 +199,8 @@ int main(int argc, char *argv[]) {
 
     /* turn off borders, enable floating on sway */
     if (wm == "sway") {
-        auto* cmd = "swaymsg -q for_window [title=\"~nwgdmenu*\"] floating enable";
-        std::system(cmd);
-        cmd = "swaymsg -q for_window [title=\"~nwgdmenu*\"] border none";
-        std::system(cmd);
+        SwaySock sock;
+        sock.run("for_window [title=\"~nwgdmenu*\"] floating enable,border none");
     }
 
     Gtk::Main kit(argc, argv);

--- a/grid/grid.cc
+++ b/grid/grid.cc
@@ -290,6 +290,7 @@ int main(int argc, char *argv[]) {
     auto icon_theme = Gtk::IconTheme::get_for_screen(screen);
     if (!icon_theme) {
         std::cerr << "ERROR: Failed to load icon theme\n";
+        std::exit(EXIT_FAILURE);
     }
     auto& icon_theme_ref = *icon_theme.get();
     auto icon_missing = Gdk::Pixbuf::create_from_file(DATA_DIR_STR "/nwgbar/icon-missing.svg");
@@ -309,11 +310,9 @@ int main(int argc, char *argv[]) {
     << h << '\n';
 
     /* turn off borders, enable floating on sway */
-    if (wm == "sway") { // TODO: Use sway-ipc
-        auto* cmd = "swaymsg for_window [title=\"~nwggrid*\"] floating enable";
-        std::system(cmd);
-        cmd = "swaymsg for_window [title=\"~nwggrid*\"] border none";
-        std::system(cmd);
+    if (wm == "sway") {
+        SwaySock sock;
+        sock.run("for_window [title=~nwggrid*] floating enable,border none");
     }
 
     if (wm == "sway" || wm == "i3" || wm == "openbox") {


### PR DESCRIPTION
This PR introduces SwaySock struct, handling Sway requests.

Before merging I'd like to discuss whether it should be in `nwg_tools` or moved into separate header/source file -- and take appropriate action.