### PR TITLE
Temporary fix for #176

### DIFF
--- a/common/nwg_classes.h
+++ b/common/nwg_classes.h
@@ -143,6 +143,8 @@ struct Instance {
 
     Instance(Gtk::Application& app, std::string_view name);
     virtual ~Instance();
+    // note: the provided implementation of on_{sigterm,sigint} handlers
+    // calls Gtk::Application::quit, which does NOT call any destructors
     virtual void on_sigterm();
     virtual void on_sigusr1();
     virtual void on_sighup();

--- a/grid/grid.h
+++ b/grid/grid.h
@@ -380,13 +380,18 @@ struct GridInstance: public Instance {
     {
         // intentionally left blank
     }
-    /* Instance::on_sig{int,term} call Application::quit, which in turn emit shutdown signal
-     * However, window.save_cache bound to said event doesn't get called for some reason
-     * So we call it ourselves before calling Application::quit */
+    /* Instance on_* handlers call Application::quit
+     * which internally calls _exit, destructors are not called
+     * To handle this problem GridInstance overrides handlers
+     * to call Application::release
+     */
     void on_sighup() override;  // reload
     void on_sigint() override;  // save & exit
     void on_sigterm() override;  // save & exit
     void on_sigusr1() override; // show
+    ~GridInstance() {
+        window.save_cache();
+    }
 };
 
 /*

--- a/grid/grid_classes.cc
+++ b/grid/grid_classes.cc
@@ -486,11 +486,9 @@ void GridInstance::on_sigusr1() {
 }
 
 void GridInstance::on_sigint() {
-    window.save_cache();
-    Instance::on_sigint();
+    app.release();
 }
 
 void GridInstance::on_sigterm() {
-    window.save_cache();
-    Instance::on_sigterm();
+    app.release();
 }

--- a/grid/grid_entries.h
+++ b/grid/grid_entries.h
@@ -86,6 +86,9 @@ private:
     void set_entry_stats(Entry& entry) {
         if (auto result = std::find(pins.begin(), pins.end(), entry.desktop_id); result != pins.end()) {
             entry.stats.pinned = Stats::Pinned;
+            // temporary fix for #176
+            // see comments to PinnedBoxes class
+            entry.stats.position = (pins.end() - result) - pins.size() - 1;
         }
         auto cmp = [&entry](auto && fav){ return entry.desktop_id == fav.desktop_id; };
         if (auto result = std::find_if(favs.begin(), favs.end(), cmp); result != favs.end()) {

--- a/grid/grid_entries.h
+++ b/grid/grid_entries.h
@@ -88,7 +88,7 @@ private:
             entry.stats.pinned = Stats::Pinned;
             // temporary fix for #176
             // see comments to PinnedBoxes class
-            entry.stats.position = (pins.end() - result) - pins.size() - 1;
+            entry.stats.position = (result - pins.begin()) - pins.size() - 1;
         }
         auto cmp = [&entry](auto && fav){ return entry.desktop_id == fav.desktop_id; };
         if (auto result = std::find_if(favs.begin(), favs.end(), cmp); result != favs.end()) {


### PR DESCRIPTION
Because pins are managed by PinnedBoxes container now,
old positioning method doesn't work. This commit is a hack
restoring the old behaviour at small cost. It makes use of
`Stats::position` being an `int` and thus allowing negative
values. This won't work nice with updating/reloading entries
and therefore must be rewritten in a proper way.