### PR TITLE
Unbreak build with libc++ < 11

### DIFF
--- a/common/nwg_exceptions.cc
+++ b/common/nwg_exceptions.cc
@@ -9,6 +9,7 @@
  * */
 
 
+#include <cerrno>
 #include <cstring>
 #include "nwg_exceptions.h"
 


### PR DESCRIPTION
Found on FreeBSD 11.4/12.2. Later versions (CI uses FreeBSD 13.0) are not affected as `<errno.h>` is bootlegged via `<string>` in common/nwg_exceptions.h