### PR TITLE
Unbreak build with libc++ 13

### DIFF
--- a/common/nwg_classes.h
+++ b/common/nwg_classes.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <array>
 #include <string>
 #include <vector>
 #include <variant>


### PR DESCRIPTION
Regressed by https://github.com/llvm/llvm-project/commit/0849427faeab8. Affects future FreeBSD versions: [14.0](https://lists.freebsd.org/archives/freebsd-current/2021-November/000947.html), 13.1, 12.4.

Clang/libc++ error:
```c++
$ export CC=clang13 CXX=clang++13 CXXFLAGS="-stdlib=libc++"
$ meson setup _build
$ meson compile -C _build
[...]
In file included from bar/bar.cc:12:
common/nwg_classes.h:200:33: error: no viable constructor or deduction guide for deduction of template arguments of 'array'
    static constexpr std::array MAGIC { 'i', '3', '-', 'i', 'p', 'c' };
                                ^
/usr/include/c++/v1/__tuple:219:64: note: candidate function template not viable: requires 1 argument, but 6 were provided
template <class _Tp, size_t _Size> struct _LIBCPP_TEMPLATE_VIS array;
                                                               ^
/usr/include/c++/v1/__tuple:219:64: note: candidate function template not viable: requires 0 arguments, but 6 were provided
```
GCC/libc++ error:
```c++
$ export CC=gcc11 CXX=g++11 CXXFLAGS="-nostdinc++ -isystem/usr/include/c++/v1"
$ meson setup _build
$ meson compile -C _build
[...]
In file included from bar/bar.cc:12:
common/nwg_classes.h:200:70: error: class template argument deduction failed:
  200 |     static constexpr std::array MAGIC { 'i', '3', '-', 'i', 'p', 'c' };
      |                                                                      ^
common/nwg_classes.h:200:70: error: no matching function for call to 'array(char, char, char, char, char, char)'
In file included from /usr/include/c++/v1/utility:212,
                 from /usr/include/c++/v1/__functional_base:26,
                 from /usr/include/c++/v1/string:520,
                 from common/nwg_classes.h:14,
                 from bar/bar.cc:12:
/usr/include/c++/v1/__tuple:219:64: note: candidate: 'template<class _Tp, long unsigned int _Size> array()-> std::__1::array<_Tp, _Size>'
  219 | template <class _Tp, size_t _Size> struct _LIBCPP_TEMPLATE_VIS array;
      |                                                                ^~~~~
/usr/include/c++/v1/__tuple:219:64: note:   template argument deduction/substitution failed:
In file included from bar/bar.cc:12:
common/nwg_classes.h:200:70: note:   candidate expects 0 arguments, 6 provided
  200 |     static constexpr std::array MAGIC { 'i', '3', '-', 'i', 'p', 'c' };
      |                                                                      ^
In file included from /usr/include/c++/v1/utility:212,
                 from /usr/include/c++/v1/__functional_base:26,
                 from /usr/include/c++/v1/string:520,
                 from common/nwg_classes.h:14,
                 from bar/bar.cc:12:
/usr/include/c++/v1/__tuple:219:64: note: candidate: 'template<class _Tp, long unsigned int _Size> array(std::__1::array<_Tp, _Size>)-> std::__1::array<_Tp, _Size>'
  219 | template <class _Tp, size_t _Size> struct _LIBCPP_TEMPLATE_VIS array;
      |                                                                ^~~~~
/usr/include/c++/v1/__tuple:219:64: note:   template argument deduction/substitution failed:
In file included from bar/bar.cc:12:
common/nwg_classes.h:200:70: note:   mismatched types 'std::__1::array<_Tp, _Size>' and 'char'
  200 |     static constexpr std::array MAGIC { 'i', '3', '-', 'i', 'p', 'c' };
      |                                                                      ^
```
http://www.ipv6proxy.net/go.php?u=http://gohan04.nyi.freebsd.org/data/mainamd64PR258209-default/2021-10-16_18h41m03s/logs/errors/nwg-launchers-0.6.3.log
