### PR TITLE
Support for changing GTK theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Options:
 -s <size>        button image size (default: 72)
 -c <name>        css file name (default: style.css)
 -l <ln>          force use of <ln> language
+-g <theme>       GTK theme name
 -wm <wmname>     window manager name (if can not be detected)
 -oneshot         run in the foreground, exit when window is closed
                  generally you should not use this option, use simply `nwggrid` instead
@@ -169,6 +170,7 @@ Options:
 -o <opacity>     background opacity (0.0 - 1.0, default 0.9)
 -b <background>  background colour in RRGGBB or RRGGBBAA format (RRGGBBAA alpha overrides <opacity>)
 -s <size>        button image size (default: 72)
+-g <theme>       GTK theme name
 -wm <wmname>     window manager name (if can not be detected)
 
 [requires layer-shell]:
@@ -271,6 +273,7 @@ Options:
 -c <name>        css file name (default: style.css)
 -o <opacity>     background opacity (0.0 - 1.0, default 0.3)
 -b <background>  background colour in RRGGBB or RRGGBBAA format (RRGGBBAA alpha overrides <opacity>)
+-g <theme>       GTK theme name
 -wm <wmname>     window manager name (if can not be detected)
 -run             ignore stdin, always build from commands in $PATH
 

--- a/bar/bar.cc
+++ b/bar/bar.cc
@@ -25,6 +25,7 @@ Options:\n\
 -o <opacity>     background opacity (0.0 - 1.0, default 0.9)\n\
 -b <background>  background colour in RRGGBB or RRGGBBAA format (RRGGBBAA alpha overrides <opacity>)\n\
 -s <size>        button image size (default: 72)\n\
+-g <theme>       GTK theme name\n\
 -wm <wmname>     window manager name (if can not be detected)\n\n\
 [requires layer-shell]:\n\
 -layer-shell-layer          {BACKGROUND,BOTTOM,TOP,OVERLAY},        default: OVERLAY\n\
@@ -55,7 +56,8 @@ int main(int argc, char *argv[]) {
         auto provider = Gtk::CssProvider::create();
         auto display = Gdk::Display::get_default();
         auto screen = display->get_default_screen();
-        if (!provider || !display || !screen) {
+	auto settings = Gtk::Settings::get_for_screen(screen);
+        if (!provider || !display || !settings || !screen) {
             Log::error("Failed to initialize GTK");
             return EXIT_FAILURE;
         }
@@ -64,6 +66,8 @@ int main(int argc, char *argv[]) {
             input,
             screen
         };
+
+	settings->property_gtk_theme_name() = config.theme;
 
         // default or custom template
         auto default_bar_file = config_dir / "bar.json";

--- a/common/nwg_classes.cc
+++ b/common/nwg_classes.cc
@@ -83,6 +83,10 @@ Config::Config(const InputParser& parser, std::string_view title, std::string_vi
     if (auto css_name = parser.getCmdOption("-c"); !css_name.empty()) {
         css_filename = css_name;
     }
+
+    if (auto theme = parser.getCmdOption("-g"); !theme.empty()) {
+        this->theme = theme;
+    }
 }
 
 CommonWindow::CommonWindow(Config& config): title{config.title} {

--- a/common/nwg_classes.h
+++ b/common/nwg_classes.h
@@ -71,6 +71,7 @@ enum class VAlign: unsigned int { NotSpecified = 0, Top, Bottom };
 struct Config {
     const InputParser& parser;
     std::string        wm;
+    std::string        theme;
     std::string_view   title;
     std::string_view   role;
     HAlign             halign{ HAlign::NotSpecified };

--- a/dmenu/dmenu.cc
+++ b/dmenu/dmenu.cc
@@ -29,6 +29,7 @@ Options:\n\
 -c <name>        css file name (default: style.css)\n\
 -o <opacity>     background opacity (0.0 - 1.0, default 0.3)\n\
 -b <background>  background colour in RRGGBB or RRGGBBAA format (RRGGBBAA alpha overrides <opacity>)\n\
+-g <theme>       GTK theme name\n\
 -wm <wmname>     window manager name (if can not be detected)\n\
 -run             ignore stdin, always build from commands in $PATH\n\n\
 [requires layer-shell]:\n\
@@ -60,7 +61,8 @@ int main(int argc, char *argv[]) {
         auto provider = Gtk::CssProvider::create();
         auto display = Gdk::Display::get_default();
         auto screen = display->get_default_screen();
-        if (!provider || !display || !screen) {
+	auto settings = Gtk::Settings::get_for_screen(screen);
+        if (!provider || !display || !settings || !screen) {
             Log::error("Failed to initialize GTK");
             return EXIT_FAILURE;
         }
@@ -68,6 +70,9 @@ int main(int argc, char *argv[]) {
             input,
             screen
         };
+
+	settings->property_gtk_theme_name() = config.theme;
+
         Gtk::StyleContext::add_provider_for_screen(screen, provider, GTK_STYLE_PROVIDER_PRIORITY_USER);
         {
             auto css_file = setup_css_file("nwgdmenu", config_dir, config.css_filename);

--- a/grid/grid.cc
+++ b/grid/grid.cc
@@ -30,6 +30,7 @@ Options:\n\
 -s <size>        button image size (default: 72)\n\
 -c <name>        css file name (default: style.css)\n\
 -l <ln>          force use of <ln> language\n\
+-g <theme>       GTK theme name\n\
 -wm <wmname>     window manager name (if can not be detected)\n\
 -oneshot         run in the foreground, exit when window is closed\n\
                  generally you should not use this option, use simply `nwggrid` instead\n\
@@ -104,7 +105,8 @@ int main(int argc, char *argv[]) {
         auto provider = Gtk::CssProvider::create();
         auto display = Gdk::Display::get_default();
         auto screen = display->get_default_screen();
-        if (!provider || !display || !screen) {
+	auto settings = Gtk::Settings::get_for_screen(screen);
+        if (!provider || !display || !settings || !screen) {
             Log::error("Failed to initialize GTK");
             return EXIT_FAILURE;
         }
@@ -115,6 +117,8 @@ int main(int argc, char *argv[]) {
             config_dir
         };
         Log::info("Locale: ", config.lang);
+
+	settings->property_gtk_theme_name() = config.theme;
 
         Gtk::StyleContext::add_provider_for_screen(screen, provider, GTK_STYLE_PROVIDER_PRIORITY_USER);
         {


### PR DESCRIPTION
This pull request adds a minor feature I consider useful. It adds an argument `-g` to change the GTK theme.
Unlike changing themes with the `GTK_THEME` environment variable, the change doesn't effect launched applications.
I tested this on my own setup with i3 and encountered no issues. Also briefly tested with openbox and sway.