### PR TITLE
CI: unbreak FreeBSD

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -16,11 +16,11 @@ on:
 
 jobs:
   clang:
-    runs-on: macos-latest # until https://github.com/actions/runner/issues/385
+    runs-on: macos-12 # until https://github.com/actions/runner/issues/385
     steps:
     - uses: actions/checkout@v2
     - name: Test in FreeBSD VM
-      uses: vmactions/freebsd-vm@v0.1.5 # aka FreeBSD 13.0
+      uses: vmactions/freebsd-vm@v0
       with:
         usesh: true
         prepare: |


### PR DESCRIPTION
FreeBSD Project currently doesn't keep recent binary packages for EOL versions. `/release_0` packages (non-default) frozen at 13.0 release (2021-04-13) will remain after 13.0 EOL (2022-08-31) for 13.* branch lifetime (until 2026-01-31) but maybe too old for nwg-launchers CI.